### PR TITLE
feat(test): add unit and integration tests for login page

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,35 @@
+name: Frontend Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run Frontend Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ./frontend/package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+        working-directory: ./frontend
+
+      - name: Run Tests
+        run: npm test
+        working-directory: ./frontend

--- a/frontend/src/hooks/useAuthForm.js
+++ b/frontend/src/hooks/useAuthForm.js
@@ -1,0 +1,109 @@
+import { useContext, useEffect, useState } from 'react'
+import axios from 'axios'
+import { toast } from 'react-toastify'
+import { ShopContext } from '../context/ShopContext'
+
+const AUTH_STATES = {
+  LOGIN: 'Login',
+  SIGN_UP: 'Sign Up',
+}
+
+const useAuthForm = () => {
+  const { token, setToken, navigate, backendUrl } = useContext(ShopContext)
+
+  const [currentState, setCurrentState] = useState(AUTH_STATES.LOGIN)
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  const persistToken = (token) => {
+    setToken(token)
+    localStorage.setItem('token', token)
+  }
+
+  const validatePassword = () => {
+    if (password !== confirmPassword) {
+      toast.error("Passwords don't match")
+      return false
+    }
+
+    if (password.length < 8) {
+      toast.error('Password must be at least 8 characters long')
+      return false
+    }
+
+    const specialCharRegex = /[!@#$%^&*(),.?":{}|<>]/
+    if (!specialCharRegex.test(password)) {
+      toast.error('Password must contain at least one special character')
+      return false
+    }
+
+    return true
+  }
+
+  const handleSignUp = async () => {
+    if (!validatePassword()) return
+
+    const res = await axios.post(`${backendUrl}/api/user/register`, {
+      name,
+      email,
+      password,
+    })
+
+    if (res.data.success) {
+      persistToken(res.data.token)
+    } else {
+      toast.error(res.data.message)
+    }
+  }
+
+  const handleLogin = async () => {
+    const res = await axios.post(`${backendUrl}/api/user/login`, {
+      email,
+      password,
+    })
+
+    if (res.data.success) {
+      persistToken(res.data.token)
+    } else {
+      toast.error(res.data.message)
+    }
+  }
+
+  const onSubmitHandler = async (e) => {
+    e.preventDefault()
+
+    try {
+      if (currentState === AUTH_STATES.SIGN_UP) {
+        await handleSignUp()
+      } else {
+        await handleLogin()
+      }
+    } catch (error) {
+      toast.error(error.message)
+    }
+  }
+
+  useEffect(() => {
+    if (token) {
+      navigate('/')
+    }
+  }, [token, navigate])
+
+  return {
+    currentState,
+    setCurrentState,
+    name,
+    setName,
+    email,
+    setEmail,
+    password,
+    setPassword,
+    confirmPassword,
+    setConfirmPassword,
+    onSubmitHandler,
+  }
+}
+
+export default useAuthForm

--- a/frontend/src/hooks/useAuthForm.test.jsx
+++ b/frontend/src/hooks/useAuthForm.test.jsx
@@ -1,0 +1,229 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import { toast } from 'react-toastify'
+import { ShopContext } from '../context/ShopContext'
+import useAuthForm from './useAuthForm'
+
+// Mock external dependencies
+vi.mock('axios')
+vi.mock('react-toastify')
+
+// Create a wrapper component to provide the mock context
+const createWrapper = (contextValue) => {
+  const Wrapper = ({ children }) => (
+    <ShopContext.Provider value={contextValue}>{children}</ShopContext.Provider>
+  )
+  return Wrapper
+}
+
+describe('useAuthForm Hook (Sign-Up Logic)', () => {
+  let mockNavigate
+  let mockSetToken
+  let localStorageSpy
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks()
+
+    // Setup default mock implementations
+    mockNavigate = vi.fn()
+    mockSetToken = vi.fn()
+    axios.post.mockResolvedValue({ data: {} }) // Default happy path
+    toast.error.mockClear()
+
+    // Spy on localStorage
+    localStorageSpy = vi.spyOn(Storage.prototype, 'setItem')
+  })
+
+  afterEach(() => {
+    // Restore localStorage spy
+    localStorageSpy.mockRestore()
+  })
+
+  const renderAuthHook = (contextValue = {}) => {
+    const defaultContext = {
+      token: null,
+      setToken: mockSetToken,
+      navigate: mockNavigate,
+      backendUrl: 'http://localhost:1001',
+      ...contextValue,
+    }
+    return renderHook(() => useAuthForm(), {
+      wrapper: createWrapper(defaultContext),
+    })
+  }
+
+  describe('Sign-Up Validation Logic', () => {
+    it('should call toast.error if passwords do not match', async () => {
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setCurrentState('Sign Up')
+        result.current.setPassword('password123')
+        result.current.setConfirmPassword('wrong-password')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(toast.error).toHaveBeenCalledWith("Passwords don't match")
+      expect(axios.post).not.toHaveBeenCalled()
+    })
+
+    it('should call toast.error if password is less than 8 characters', async () => {
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setCurrentState('Sign Up')
+        result.current.setPassword('short')
+        result.current.setConfirmPassword('short')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(toast.error).toHaveBeenCalledWith(
+        'Password must be at least 8 characters long'
+      )
+      expect(axios.post).not.toHaveBeenCalled()
+    })
+
+    it('should call toast.error if password has no special characters', async () => {
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setCurrentState('Sign Up')
+        result.current.setPassword('longPassword')
+        result.current.setConfirmPassword('longPassword')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(toast.error).toHaveBeenCalledWith(
+        'Password must contain at least one special character'
+      )
+      expect(axios.post).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Sign-Up API Calls', () => {
+    it('should make a POST request to the register endpoint and handle success', async () => {
+      axios.post.mockResolvedValue({
+        data: { success: true, token: 'fake-token' },
+      })
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setCurrentState('Sign Up')
+        result.current.setName('John')
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('ValidPass123!')
+        result.current.setConfirmPassword('ValidPass123!')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/user/register',
+        {
+          name: 'John',
+          email: 'john@test.com',
+          password: 'ValidPass123!',
+        }
+      )
+      expect(mockSetToken).toHaveBeenCalledWith('fake-token')
+      expect(localStorageSpy).toHaveBeenCalledWith('token', 'fake-token')
+    })
+
+    it('should call toast.error with the API message on a failed registration', async () => {
+      axios.post.mockResolvedValue({
+        data: { success: false, message: 'API error from test' },
+      })
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setCurrentState('Sign Up')
+        result.current.setName('John')
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('ValidPass123!')
+        result.current.setConfirmPassword('ValidPass123!')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(toast.error).toHaveBeenCalledWith('API error from test')
+    })
+
+    it('should call toast.error when registration request throws', async () => {
+      axios.post.mockRejectedValue(new Error('Network error'))
+
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setCurrentState('Sign Up')
+        result.current.setName('John')
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('ValidPass123!')
+        result.current.setConfirmPassword('ValidPass123!')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(toast.error).toHaveBeenCalledWith('Network error')
+    })
+
+    it('should call preventDefault when the form is submitted', async () => {
+      const { result } = renderAuthHook()
+      const preventDefault = vi.fn()
+
+      act(() => {
+        result.current.setCurrentState('Sign Up')
+        result.current.setName('John')
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('ValidPass123!')
+        result.current.setConfirmPassword('ValidPass123!')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault })
+      })
+
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Redirection Effect', () => {
+    it('should not call navigate("/") on initial render if no token is present', () => {
+      renderAuthHook({ token: null })
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('should call navigate("/") on initial render if a token is present', () => {
+      renderAuthHook({ token: 'a-real-token' })
+      expect(mockNavigate).toHaveBeenCalledWith('/')
+    })
+  })
+
+  describe('Default state of Sign-up', () => {
+    it('should initialize with Login state and empty fields', () => {
+      const { result } = renderAuthHook()
+
+      expect(result.current.currentState).toBe('Login')
+      expect(result.current.name).toBe('')
+      expect(result.current.email).toBe('')
+      expect(result.current.password).toBe('')
+      expect(result.current.confirmPassword).toBe('')
+    })
+  })
+})

--- a/frontend/src/pages/Login.integration.test.jsx
+++ b/frontend/src/pages/Login.integration.test.jsx
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import { ShopContext } from '../context/ShopContext'
+import Login from './Login' // The component we are testing
+import { MemoryRouter } from 'react-router-dom' // To mock navigation
+
+// Mock external dependencies
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+// Create a helper to render the component with a provider
+const renderWithContext = (contextValue) => {
+  return render(
+    <MemoryRouter>
+      <ShopContext.Provider value={contextValue}>
+        <Login />
+      </ShopContext.Provider>
+    </MemoryRouter>
+  )
+}
+
+describe('Signup Form Integration Tests', () => {
+  let mockNavigate
+  let mockSetToken
+  let localStorageSpy
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks()
+
+    // Default mock implementations
+    mockNavigate = vi.fn()
+    mockSetToken = vi.fn()
+    axios.post.mockResolvedValue({ data: {} }) // Default happy path
+
+    // Spy on localStorage
+    localStorageSpy = vi.spyOn(Storage.prototype, 'setItem')
+  })
+
+  afterEach(() => {
+    // Restore localStorage spy
+    localStorageSpy.mockRestore()
+    localStorage.clear()
+  })
+
+  const getContextValue = () => ({
+    token: null,
+    setToken: mockSetToken,
+    navigate: mockNavigate,
+    backendUrl: 'http://localhost:1001',
+  })
+
+  // Test 1: Successful Signup
+  it('should handle successful signup, store token, and navigate to home', async () => {
+    // Arrange: Mock a successful API response
+    axios.post.mockResolvedValue({
+      data: { success: true, token: 'fake-jwt-token' },
+    })
+    renderWithContext(getContextValue())
+
+    // Act: Switch to signup and fill out the form
+    fireEvent.click(screen.getByText('Create account'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Test User' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+    // Assert: Check API call, token storage, and navigation
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/user/register',
+        {
+          name: 'Test User',
+          email: 'test@example.com',
+          password: 'Password123!',
+        }
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockSetToken).toHaveBeenCalledWith('fake-jwt-token')
+      expect(localStorageSpy).toHaveBeenCalledWith('token', 'fake-jwt-token')
+    })
+  })
+
+  // Test 2: Signup with an existing email
+  it('should show an error message when signing up with an existing email', async () => {
+    // Arrange: Mock an API response for a duplicate user
+    axios.post.mockResolvedValue({
+      data: { success: false, message: 'User already exists' },
+    })
+    const { toast } = await import('react-toastify')
+    renderWithContext(getContextValue())
+
+    // Act: Fill and submit the form
+    fireEvent.click(screen.getByText('Create account'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Test User' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'existing@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+    // Assert: Check for the error toast and that no token is set
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('User already exists')
+    })
+
+    expect(mockSetToken).not.toHaveBeenCalled()
+    expect(localStorageSpy).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  // Test 3: Signup with non-matching passwords
+  it('should show a validation error if passwords do not match', async () => {
+    const { toast } = await import('react-toastify')
+    renderWithContext(getContextValue())
+
+    // Act: Fill form with non-matching passwords
+    fireEvent.click(screen.getByText('Create account'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Test User' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'WrongPassword' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+    // Assert: Check for the validation error and that no API call was made
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Passwords don't match")
+    })
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,70 +1,25 @@
-import { useContext, useEffect, useState } from 'react'
-import { ShopContext } from '../context/ShopContext'
-import axios from 'axios'
-import { toast } from 'react-toastify'
+import useAuthForm from '../hooks/useAuthForm'
 
 const Login = () => {
-  const { token, setToken, navigate, backendUrl } = useContext(ShopContext)
-  const [currentState, setCurrentState] = useState('Login')
+  const {
+    currentState,
+    setCurrentState,
+    name,
+    setName,
+    email,
+    setEmail,
+    password,
+    setPassword,
+    confirmPassword,
+    setConfirmPassword,
+    onSubmitHandler,
+  } = useAuthForm()
 
-  const [name, setName] = useState('')
-  const [password, setPassword] = useState('')
-  const [email, setEmail] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-
-  const onSubmitHandler = async (e) => {
-    e.preventDefault()
-    try {
-      if (currentState === 'Sign Up') {
-        if (password !== confirmPassword) {
-          toast.error("Passwords don't match")
-          return
-        }
-        if (password.length < 8) {
-          toast.error('Password must be at least 8 characters long')
-          return
-        }
-        const specialCharRegex = /[!@#$%^&*(),.?":{}|<>]/
-        if (!specialCharRegex.test(password)) {
-          toast.error('Password must contain at least one special character')
-          return
-        }
-        const res = await axios.post(backendUrl + '/api/user/register', {
-          name,
-          email,
-          password,
-        })
-
-        if (res.data.success) {
-          setToken(res.data.token)
-          localStorage.setItem('token', res.data.token)
-        } else {
-          toast.error(res.data.message)
-        }
-      } else {
-        const res = await axios.post(backendUrl + '/api/user/login', {
-          email,
-          password,
-        })
-
-        if (res.data.success) {
-          setToken(res.data.token)
-          localStorage.setItem('token', res.data.token)
-        } else {
-          toast.error(res.data.message)
-        }
-      }
-    } catch (error) {
-      console.log(error)
-      toast.error(error.message)
-    }
-  }
-
-  useEffect(() => {
-    if (token) {
-      navigate('/')
-    }
-  }, [token, navigate])
+  const isLogin = currentState === 'Login'
+  const isSignUp = currentState === 'Sign Up'
+  const nextState = isLogin ? 'Sign Up' : 'Login'
+  const stateToggleText = isLogin ? 'Create account' : 'Login Here'
+  const submitButtonText = isLogin ? 'Sign In' : 'Sign Up'
 
   return (
     <form
@@ -72,13 +27,11 @@ const Login = () => {
       className='flex flex-col items-center w-[90%] sm:max-w-96 m-auto mt-14 gap-4 text-gray-800'
     >
       <div className='inline-flex items-center gap-2 mb-2 mt-10'>
-        <p className='prata-regular text-3xl'>{currentState}</p>
+        <h1 className='prata-regular text-3xl'>{currentState}</h1>
         <hr className='border-none h-[1.5px] w-8 bg-gray-800' />
       </div>
 
-      {currentState === 'Login' ? (
-        ''
-      ) : (
+      {isSignUp && (
         <input
           type='text'
           className='w-full px-3 py-2 border border-gray-800'
@@ -88,6 +41,7 @@ const Login = () => {
           value={name}
         />
       )}
+
       <input
         type='email'
         className='w-full px-3 py-2 border border-gray-800'
@@ -96,6 +50,7 @@ const Login = () => {
         onChange={(e) => setEmail(e.target.value)}
         value={email}
       />
+
       <input
         type='password'
         className='w-full px-3 py-2 border border-gray-800'
@@ -104,7 +59,8 @@ const Login = () => {
         onChange={(e) => setPassword(e.target.value)}
         value={password}
       />
-      {currentState === 'Sign Up' && (
+
+      {isSignUp && (
         <input
           type='password'
           className='w-full px-3 py-2 border border-gray-800'
@@ -116,30 +72,22 @@ const Login = () => {
       )}
 
       <div className='w-full flex justify-between text-sm mt-[-8px]'>
-        {currentState === 'Login' ? (
+        {isLogin ? (
           <p className='cursor-pointer'>Forgot your password?</p>
         ) : (
-          <span></span>
+          <span />
         )}
-        {currentState === 'Login' ? (
-          <p
-            onClick={() => setCurrentState('Sign Up')}
-            className='cursor-pointer'
-          >
-            Create account
-          </p>
-        ) : (
-          <p
-            onClick={() => setCurrentState('Login')}
-            className='cursor-pointer'
-          >
-            Login Here{' '}
-          </p>
-        )}
+
+        <p
+          onClick={() => setCurrentState(nextState)}
+          className='cursor-pointer'
+        >
+          {stateToggleText}
+        </p>
       </div>
 
       <button className='bg-black text-white font-light px-8 py-2 mt-4'>
-        {currentState === 'Login' ? 'Sign In' : 'Sign Up'}
+        {submitButtonText}
       </button>
     </form>
   )

--- a/frontend/src/pages/Login.test.jsx
+++ b/frontend/src/pages/Login.test.jsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Login from './Login'
+import useAuthForm from '../hooks/useAuthForm'
+
+// Mock the custom hook
+vi.mock('../hooks/useAuthForm')
+
+describe('Login Component (Sign Up State)', () => {
+  // Create mock functions that can be reused in tests
+  const mockSetCurrentState = vi.fn()
+  const mockSetName = vi.fn()
+  const mockSetEmail = vi.fn()
+  const mockSetPassword = vi.fn()
+  const mockSetConfirmPassword = vi.fn()
+  const mockOnSubmitHandler = vi.fn((e) => e.preventDefault())
+
+  // Set a default mock implementation for all tests
+  const mockAuthForm = (overrides = {}) => {
+    useAuthForm.mockReturnValue({
+      currentState: 'Sign Up',
+      name: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+      setCurrentState: mockSetCurrentState,
+      setName: mockSetName,
+      setEmail: mockSetEmail,
+      setPassword: mockSetPassword,
+      setConfirmPassword: mockSetConfirmPassword,
+      onSubmitHandler: mockOnSubmitHandler,
+      ...overrides,
+    })
+  }
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks()
+    mockAuthForm()
+  })
+
+  describe('Rendering', () => {
+    it('should render the complete Sign Up form correctly', () => {
+      render(<Login />)
+
+      // Assert titles and buttons
+      expect(
+        screen.getByRole('heading', { name: /Sign Up/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /Sign Up/i })
+      ).toBeInTheDocument()
+      expect(screen.getByText('Login Here')).toBeInTheDocument()
+
+      // Assert input fields are present
+      expect(screen.getByPlaceholderText('Name')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Email')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Password')).toBeInTheDocument()
+      expect(
+        screen.getByPlaceholderText('Confirm Password')
+      ).toBeInTheDocument()
+
+      // Assert elements that should NOT be present
+      expect(
+        screen.queryByText('Forgot your password?')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should render input values from the hook', () => {
+      mockAuthForm({
+        name: 'John',
+        email: 'john@test.com',
+        password: 'Password123!',
+        confirmPassword: 'Password123!',
+      })
+
+      render(<Login />)
+
+      expect(screen.getByPlaceholderText('Name')).toHaveValue('John')
+      expect(screen.getByPlaceholderText('Email')).toHaveValue('john@test.com')
+      expect(screen.getByPlaceholderText('Password')).toHaveValue(
+        'Password123!'
+      )
+      expect(screen.getByPlaceholderText('Confirm Password')).toHaveValue(
+        'Password123!'
+      )
+    })
+  })
+
+  describe('User Interactions', () => {
+    it('should call setName when user types in the name field', () => {
+      render(<Login />)
+      const nameInput = screen.getByPlaceholderText('Name')
+      fireEvent.change(nameInput, { target: { value: 'John' } })
+      expect(mockSetName).toHaveBeenCalledWith('John')
+    })
+
+    it('should call setEmail when user types in the email field', () => {
+      render(<Login />)
+      const emailInput = screen.getByPlaceholderText('Email')
+      fireEvent.change(emailInput, { target: { value: 'test@email.com' } })
+      expect(mockSetEmail).toHaveBeenCalledWith('test@email.com')
+    })
+
+    it('should call setPassword when user types in the password field', () => {
+      render(<Login />)
+      const passwordInput = screen.getByPlaceholderText('Password')
+      fireEvent.change(passwordInput, { target: { value: 'pass123' } })
+      expect(mockSetPassword).toHaveBeenCalledWith('pass123')
+    })
+
+    it('should call setConfirmPassword when user types in the confirm password field', () => {
+      render(<Login />)
+      const confirmPasswordInput =
+        screen.getByPlaceholderText('Confirm Password')
+      fireEvent.change(confirmPasswordInput, { target: { value: 'pass123' } })
+      expect(mockSetConfirmPassword).toHaveBeenCalledWith('pass123')
+    })
+
+    it('should call onSubmitHandler when the Sign Up button is clicked', () => {
+      mockAuthForm({
+        name: 'John',
+        email: 'john@test.com',
+        password: 'Password123!',
+        confirmPassword: 'Password123!',
+      })
+      render(<Login />)
+
+      const signUpButton = screen.getByRole('button', { name: /Sign Up/i })
+      fireEvent.click(signUpButton)
+      expect(mockOnSubmitHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call setCurrentState when the "Login Here" link is clicked', () => {
+      render(<Login />)
+      const loginLink = screen.getByText('Login Here')
+      fireEvent.click(loginLink)
+      expect(mockSetCurrentState).toHaveBeenCalledWith('Login')
+    })
+  })
+})


### PR DESCRIPTION
### Purpose

This pull request introduces a comprehensive test suite for the login functionality, including unit tests, integration tests, and a new custom hook for form authentication logic. It also sets up a new GitHub Actions workflow to run these frontend tests automatically.

### Changes

-   **New Tests:**
    -   Unit tests for the `Login` component (`frontend/src/pages/Login.test.jsx`).
    -   Integration tests for the `Login` component (`frontend/src/pages/Login.integration.test.jsx`).
    -   Unit tests for the new `useAuthForm` hook (`frontend/src/hooks/useAuthForm.test.jsx`).
-   **New Hook:**
    -   Adds a `useAuthForm` custom hook to encapsulate authentication form logic (`frontend/src/hooks/useAuthForm.js`).
-   **Refactoring:**
    -   Refactors the `Login` component to use the new `useAuthForm` hook (`frontend/src/pages/Login.jsx`).
-   **CI/CD:**
    -   Adds a new GitHub Actions workflow to run frontend tests on push and pull requests (`.github/workflows/frontend-tests.yml`).

### How to test

1.  Pull down this branch.
2.  Run `npm install` in the `frontend` directory.
3.  Run `npm test` in the `frontend` directory to see all new tests passing.
4.  Optionally, you can inspect the new workflow in the "Actions" tab of the GitHub repository after pushing.