### PR TITLE
feat(login): Unit and integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-
+graphify-out
 *.env

--- a/backend/controllers/loginUser.test.js
+++ b/backend/controllers/loginUser.test.js
@@ -1,0 +1,134 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// ─── Mock setup ───────────────────────────────────────────────────────────────
+// These must be declared BEFORE any dynamic import of the module under test.
+
+const mockFindOne = jest.fn()
+const MockUserModel = jest.fn()
+MockUserModel.findOne = mockFindOne
+
+jest.unstable_mockModule('../models/userModel.js', () => ({
+  default: MockUserModel,
+}))
+
+jest.unstable_mockModule('bcrypt', () => ({
+  default: { compare: jest.fn() },
+}))
+
+jest.unstable_mockModule('jsonwebtoken', () => ({
+  default: { sign: jest.fn() },
+}))
+
+// ─── Dynamic imports (must come after mock registration) ──────────────────────
+const { loginUser } = await import('./userController.js')
+const { default: bcrypt } = await import('bcrypt')
+const { default: jwt } = await import('jsonwebtoken')
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+const makeReqRes = (body) => ({
+  req: { body },
+  res: { json: jest.fn() },
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+describe('loginUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.JWT_SECRET = 'test-secret'
+  })
+
+  it('returns success: false when the user does not exist', async () => {
+    mockFindOne.mockResolvedValue(null)
+
+    const { req, res } = makeReqRes({
+      email: 'nobody@example.com',
+      password: 'Password123!',
+    })
+
+    await loginUser(req, res)
+
+    expect(mockFindOne).toHaveBeenCalledWith({ email: 'nobody@example.com' })
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'User does not exists',
+    })
+    // Should not attempt password comparison if user not found
+    expect(bcrypt.compare).not.toHaveBeenCalled()
+  })
+
+  it('returns success: false when the password does not match', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'user-id',
+      password: 'hashedPassword',
+    })
+    bcrypt.compare.mockResolvedValue(false)
+
+    const { req, res } = makeReqRes({
+      email: 'alice@example.com',
+      password: 'wrongPassword',
+    })
+
+    await loginUser(req, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Invalid Credentials',
+    })
+  })
+
+  it('calls bcrypt.compare with the plaintext password and the stored hash', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'user-id',
+      password: 'storedHash',
+    })
+    bcrypt.compare.mockResolvedValue(true)
+    jwt.sign.mockReturnValue('fake-token')
+
+    const { req, res } = makeReqRes({
+      email: 'alice@example.com',
+      password: 'Password123!',
+    })
+
+    await loginUser(req, res)
+
+    expect(bcrypt.compare).toHaveBeenCalledWith('Password123!', 'storedHash')
+  })
+
+  it('creates a token with the user ID on successful login', async () => {
+    mockFindOne.mockResolvedValue({
+      _id: 'user-id-123',
+      password: 'hashedPassword',
+    })
+    bcrypt.compare.mockResolvedValue(true)
+    jwt.sign.mockReturnValue('fake-token')
+
+    const { req, res } = makeReqRes({
+      email: 'alice@example.com',
+      password: 'Password123!',
+    })
+
+    await loginUser(req, res)
+
+    expect(jwt.sign).toHaveBeenCalledWith({ id: 'user-id-123' }, 'test-secret')
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      token: 'fake-token',
+    })
+  })
+
+  it('returns success: false with the error message when an exception is thrown', async () => {
+    mockFindOne.mockRejectedValue(new Error('Database connection lost'))
+
+    const { req, res } = makeReqRes({
+      email: 'alice@example.com',
+      password: 'Password123!',
+    })
+
+    await loginUser(req, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Database connection lost',
+    })
+  })
+})

--- a/backend/routes/userLogin.integration.test.js
+++ b/backend/routes/userLogin.integration.test.js
@@ -1,0 +1,95 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+import bcrypt from 'bcrypt'
+import userRouter from './userRoutes.js'
+import userModel from '../models/userModel.js'
+
+// ─── Test app ─────────────────────────────────────────────────────────────────
+const app = express()
+app.use(express.json())
+app.use('/api/user', userRouter)
+
+// ─── Database setup ───────────────────────────────────────────────────────────
+let mongoServer
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'test-secret'
+  mongoServer = await MongoMemoryServer.create()
+  await mongoose.connect(mongoServer.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+afterEach(async () => {
+  await userModel.deleteMany({})
+})
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+// Seeds a user directly in the database so login tests don't depend on the
+// registration endpoint.
+const seedUser = async (
+  email = 'alice@example.com',
+  password = 'Password123!'
+) => {
+  const hashedPassword = await bcrypt.hash(password, 10)
+  const user = new userModel({
+    name: 'Alice',
+    email,
+    password: hashedPassword,
+  })
+  return user.save()
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+describe('POST /api/user/login', () => {
+  it('logs in successfully and returns a token containing the user id', async () => {
+    const user = await seedUser()
+
+    const res = await request(app).post('/api/user/login').send({
+      email: 'alice@example.com',
+      password: 'Password123!',
+    })
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.token).toBeDefined()
+
+    const decoded = jwt.verify(res.body.token, process.env.JWT_SECRET)
+    expect(decoded.id).toBe(user._id.toString())
+  })
+
+  it('returns success: false when the email does not exist', async () => {
+    const res = await request(app).post('/api/user/login').send({
+      email: 'nobody@example.com',
+      password: 'Password123!',
+    })
+
+    expect(res.body.success).toBe(false)
+    expect(res.body.message).toBe('User does not exists')
+  })
+
+  it('returns success: false when the password is incorrect', async () => {
+    await seedUser()
+
+    const res = await request(app).post('/api/user/login').send({
+      email: 'alice@example.com',
+      password: 'WrongPassword!',
+    })
+
+    expect(res.body.success).toBe(false)
+    expect(res.body.message).toBe('Invalid Credentials')
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "test": "vitest",
+    "test": "vitest run",
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/frontend/src/hooks/useAuthForm.test.jsx
+++ b/frontend/src/hooks/useAuthForm.test.jsx
@@ -17,7 +17,7 @@ const createWrapper = (contextValue) => {
   return Wrapper
 }
 
-describe('useAuthForm Hook (Sign-Up Logic)', () => {
+describe('useAuthForm Hook', () => {
   let mockNavigate
   let mockSetToken
   let localStorageSpy
@@ -203,6 +203,95 @@ describe('useAuthForm Hook (Sign-Up Logic)', () => {
     })
   })
 
+  describe('Login API Calls', () => {
+    it('should make a POST request to the login endpoint and handle success', async () => {
+      axios.post.mockResolvedValue({
+        data: { success: true, token: 'login-token' },
+      })
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('Password123!')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/user/login',
+        {
+          email: 'john@test.com',
+          password: 'Password123!',
+        }
+      )
+      expect(mockSetToken).toHaveBeenCalledWith('login-token')
+      expect(localStorageSpy).toHaveBeenCalledWith('token', 'login-token')
+    })
+
+    it('should call toast.error with the API message on a failed login', async () => {
+      axios.post.mockResolvedValue({
+        data: { success: false, message: 'Invalid credentials' },
+      })
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('Password123!')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(toast.error).toHaveBeenCalledWith('Invalid credentials')
+      expect(mockSetToken).not.toHaveBeenCalled()
+    })
+
+    it('should call toast.error when login request throws', async () => {
+      axios.post.mockRejectedValue(new Error('Network error'))
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('Password123!')
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      expect(toast.error).toHaveBeenCalledWith('Network error')
+    })
+
+    it('should skip password validation and call the API directly', async () => {
+      axios.post.mockResolvedValue({
+        data: { success: true, token: 'login-token' },
+      })
+      const { result } = renderAuthHook()
+
+      act(() => {
+        result.current.setEmail('john@test.com')
+        result.current.setPassword('short') // No special char, under 8 chars
+      })
+
+      await act(async () => {
+        await result.current.onSubmitHandler({ preventDefault: () => {} })
+      })
+
+      // Login should NOT run validation — API should still be called
+      expect(toast.error).not.toHaveBeenCalled()
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/user/login',
+        {
+          email: 'john@test.com',
+          password: 'short',
+        }
+      )
+    })
+  })
+
   describe('Redirection Effect', () => {
     it('should not call navigate("/") on initial render if no token is present', () => {
       renderAuthHook({ token: null })
@@ -215,7 +304,7 @@ describe('useAuthForm Hook (Sign-Up Logic)', () => {
     })
   })
 
-  describe('Default state of Sign-up', () => {
+  describe('Default State', () => {
     it('should initialize with Login state and empty fields', () => {
       const { result } = renderAuthHook()
 

--- a/frontend/src/pages/Login.integration.test.jsx
+++ b/frontend/src/pages/Login.integration.test.jsx
@@ -2,8 +2,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import axios from 'axios'
 import { ShopContext } from '../context/ShopContext'
-import Login from './Login' // The component we are testing
-import { MemoryRouter } from 'react-router-dom' // To mock navigation
+import Login from './Login'
+import { MemoryRouter } from 'react-router-dom'
 
 // Mock external dependencies
 vi.mock('axios')
@@ -24,26 +24,20 @@ const renderWithContext = (contextValue) => {
   )
 }
 
-describe('Signup Form Integration Tests', () => {
+describe('Login Form Integration Tests', () => {
   let mockNavigate
   let mockSetToken
   let localStorageSpy
 
   beforeEach(() => {
-    // Reset mocks before each test
     vi.clearAllMocks()
-
-    // Default mock implementations
     mockNavigate = vi.fn()
     mockSetToken = vi.fn()
-    axios.post.mockResolvedValue({ data: {} }) // Default happy path
-
-    // Spy on localStorage
+    axios.post.mockResolvedValue({ data: {} })
     localStorageSpy = vi.spyOn(Storage.prototype, 'setItem')
   })
 
   afterEach(() => {
-    // Restore localStorage spy
     localStorageSpy.mockRestore()
     localStorage.clear()
   })
@@ -55,36 +49,25 @@ describe('Signup Form Integration Tests', () => {
     backendUrl: 'http://localhost:1001',
   })
 
-  // Test 1: Successful Signup
-  it('should handle successful signup, store token, and navigate to home', async () => {
-    // Arrange: Mock a successful API response
+  it('should handle successful login, store token, and navigate to home', async () => {
     axios.post.mockResolvedValue({
       data: { success: true, token: 'fake-jwt-token' },
     })
     renderWithContext(getContextValue())
 
-    // Act: Switch to signup and fill out the form
-    fireEvent.click(screen.getByText('Create account'))
-    fireEvent.change(screen.getByPlaceholderText('Name'), {
-      target: { value: 'Test User' },
-    })
+    // Fill and submit the login form (default state is Login)
     fireEvent.change(screen.getByPlaceholderText('Email'), {
       target: { value: 'test@example.com' },
     })
     fireEvent.change(screen.getByPlaceholderText('Password'), {
       target: { value: 'Password123!' },
     })
-    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
-      target: { value: 'Password123!' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }))
 
-    // Assert: Check API call, token storage, and navigation
     await waitFor(() => {
       expect(axios.post).toHaveBeenCalledWith(
-        'http://localhost:1001/api/user/register',
+        'http://localhost:1001/api/user/login',
         {
-          name: 'Test User',
           email: 'test@example.com',
           password: 'Password123!',
         }
@@ -97,66 +80,46 @@ describe('Signup Form Integration Tests', () => {
     })
   })
 
-  // Test 2: Signup with an existing email
-  it('should show an error message when signing up with an existing email', async () => {
-    // Arrange: Mock an API response for a duplicate user
+  it('should show an error toast and not store a token when login fails', async () => {
     axios.post.mockResolvedValue({
-      data: { success: false, message: 'User already exists' },
+      data: { success: false, message: 'Invalid Credentials' },
     })
     const { toast } = await import('react-toastify')
     renderWithContext(getContextValue())
 
-    // Act: Fill and submit the form
-    fireEvent.click(screen.getByText('Create account'))
-    fireEvent.change(screen.getByPlaceholderText('Name'), {
-      target: { value: 'Test User' },
-    })
     fireEvent.change(screen.getByPlaceholderText('Email'), {
-      target: { value: 'existing@example.com' },
+      target: { value: 'test@example.com' },
     })
     fireEvent.change(screen.getByPlaceholderText('Password'), {
-      target: { value: 'Password123!' },
+      target: { value: 'wrongpassword' },
     })
-    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
-      target: { value: 'Password123!' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }))
 
-    // Assert: Check for the error toast and that no token is set
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('User already exists')
+      expect(toast.error).toHaveBeenCalledWith('Invalid Credentials')
     })
 
     expect(mockSetToken).not.toHaveBeenCalled()
     expect(localStorageSpy).not.toHaveBeenCalled()
-    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  // Test 3: Signup with non-matching passwords
-  it('should show a validation error if passwords do not match', async () => {
+  it('should show an error when the network request fails', async () => {
+    axios.post.mockRejectedValue(new Error('Network Error'))
     const { toast } = await import('react-toastify')
     renderWithContext(getContextValue())
 
-    // Act: Fill form with non-matching passwords
-    fireEvent.click(screen.getByText('Create account'))
-    fireEvent.change(screen.getByPlaceholderText('Name'), {
-      target: { value: 'Test User' },
-    })
     fireEvent.change(screen.getByPlaceholderText('Email'), {
       target: { value: 'test@example.com' },
     })
     fireEvent.change(screen.getByPlaceholderText('Password'), {
       target: { value: 'Password123!' },
     })
-    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
-      target: { value: 'WrongPassword' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }))
 
-    // Assert: Check for the validation error and that no API call was made
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Passwords don't match")
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
     })
-    expect(axios.post).not.toHaveBeenCalled()
+
+    expect(mockSetToken).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/Signup.integration.test.jsx
+++ b/frontend/src/pages/Signup.integration.test.jsx
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import { ShopContext } from '../context/ShopContext'
+import Login from './Login' // The component we are testing
+import { MemoryRouter } from 'react-router-dom' // To mock navigation
+
+// Mock external dependencies
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
+
+// Create a helper to render the component with a provider
+const renderWithContext = (contextValue) => {
+  return render(
+    <MemoryRouter>
+      <ShopContext.Provider value={contextValue}>
+        <Login />
+      </ShopContext.Provider>
+    </MemoryRouter>
+  )
+}
+
+describe('Signup Form Integration Tests', () => {
+  let mockNavigate
+  let mockSetToken
+  let localStorageSpy
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks()
+
+    // Default mock implementations
+    mockNavigate = vi.fn()
+    mockSetToken = vi.fn()
+    axios.post.mockResolvedValue({ data: {} }) // Default happy path
+
+    // Spy on localStorage
+    localStorageSpy = vi.spyOn(Storage.prototype, 'setItem')
+  })
+
+  afterEach(() => {
+    // Restore localStorage spy
+    localStorageSpy.mockRestore()
+    localStorage.clear()
+  })
+
+  const getContextValue = () => ({
+    token: null,
+    setToken: mockSetToken,
+    navigate: mockNavigate,
+    backendUrl: 'http://localhost:1001',
+  })
+
+  // Test 1: Successful Signup
+  it('should handle successful signup, store token, and navigate to home', async () => {
+    // Arrange: Mock a successful API response
+    axios.post.mockResolvedValue({
+      data: { success: true, token: 'fake-jwt-token' },
+    })
+    renderWithContext(getContextValue())
+
+    // Act: Switch to signup and fill out the form
+    fireEvent.click(screen.getByText('Create account'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Test User' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+    // Assert: Check API call, token storage, and navigation
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/user/register',
+        {
+          name: 'Test User',
+          email: 'test@example.com',
+          password: 'Password123!',
+        }
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockSetToken).toHaveBeenCalledWith('fake-jwt-token')
+      expect(localStorageSpy).toHaveBeenCalledWith('token', 'fake-jwt-token')
+    })
+  })
+
+  // Test 2: Signup with an existing email
+  it('should show an error message when signing up with an existing email', async () => {
+    // Arrange: Mock an API response for a duplicate user
+    axios.post.mockResolvedValue({
+      data: { success: false, message: 'User already exists' },
+    })
+    const { toast } = await import('react-toastify')
+    renderWithContext(getContextValue())
+
+    // Act: Fill and submit the form
+    fireEvent.click(screen.getByText('Create account'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Test User' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'existing@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+    // Assert: Check for the error toast and that no token is set
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('User already exists')
+    })
+
+    expect(mockSetToken).not.toHaveBeenCalled()
+    expect(localStorageSpy).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  // Test 3: Signup with non-matching passwords
+  it('should show a validation error if passwords do not match', async () => {
+    const { toast } = await import('react-toastify')
+    renderWithContext(getContextValue())
+
+    // Act: Fill form with non-matching passwords
+    fireEvent.click(screen.getByText('Create account'))
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Test User' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'Password123!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'WrongPassword' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }))
+
+    // Assert: Check for the validation error and that no API call was made
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Passwords don't match")
+    })
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/Signup.test.jsx
+++ b/frontend/src/pages/Signup.test.jsx
@@ -6,75 +6,95 @@ import useAuthForm from '../hooks/useAuthForm'
 // Mock the custom hook
 vi.mock('../hooks/useAuthForm')
 
-describe('Login Component (Login State)', () => {
+describe('Login Component (Sign Up State)', () => {
+  // Create mock functions that can be reused in tests
   const mockSetCurrentState = vi.fn()
+  const mockSetName = vi.fn()
   const mockSetEmail = vi.fn()
   const mockSetPassword = vi.fn()
+  const mockSetConfirmPassword = vi.fn()
   const mockOnSubmitHandler = vi.fn((e) => e.preventDefault())
 
+  // Set a default mock implementation for all tests
   const mockAuthForm = (overrides = {}) => {
     useAuthForm.mockReturnValue({
-      currentState: 'Login',
+      currentState: 'Sign Up',
       name: '',
       email: '',
       password: '',
       confirmPassword: '',
       setCurrentState: mockSetCurrentState,
-      setName: vi.fn(),
+      setName: mockSetName,
       setEmail: mockSetEmail,
       setPassword: mockSetPassword,
-      setConfirmPassword: vi.fn(),
+      setConfirmPassword: mockSetConfirmPassword,
       onSubmitHandler: mockOnSubmitHandler,
       ...overrides,
     })
   }
 
   beforeEach(() => {
+    // Reset mocks before each test
     vi.clearAllMocks()
     mockAuthForm()
   })
 
   describe('Rendering', () => {
-    it('should render the login form correctly (default state is Login)', () => {
+    it('should render the complete Sign Up form correctly', () => {
       render(<Login />)
 
       // Assert titles and buttons
       expect(
-        screen.getByRole('heading', { name: /Login/i })
+        screen.getByRole('heading', { name: /Sign Up/i })
       ).toBeInTheDocument()
       expect(
-        screen.getByRole('button', { name: /Sign In/i })
+        screen.getByRole('button', { name: /Sign Up/i })
       ).toBeInTheDocument()
-      expect(screen.getByText('Create account')).toBeInTheDocument()
-      expect(screen.getByText('Forgot your password?')).toBeInTheDocument()
+      expect(screen.getByText('Login Here')).toBeInTheDocument()
 
       // Assert input fields are present
+      expect(screen.getByPlaceholderText('Name')).toBeInTheDocument()
       expect(screen.getByPlaceholderText('Email')).toBeInTheDocument()
       expect(screen.getByPlaceholderText('Password')).toBeInTheDocument()
-
-      // Assert Sign Up-only elements are NOT present
-      expect(screen.queryByPlaceholderText('Name')).not.toBeInTheDocument()
       expect(
-        screen.queryByPlaceholderText('Confirm Password')
+        screen.getByPlaceholderText('Confirm Password')
+      ).toBeInTheDocument()
+
+      // Assert elements that should NOT be present
+      expect(
+        screen.queryByText('Forgot your password?')
       ).not.toBeInTheDocument()
     })
 
     it('should render input values from the hook', () => {
       mockAuthForm({
+        name: 'John',
         email: 'john@test.com',
         password: 'Password123!',
+        confirmPassword: 'Password123!',
       })
 
       render(<Login />)
 
+      expect(screen.getByPlaceholderText('Name')).toHaveValue('John')
       expect(screen.getByPlaceholderText('Email')).toHaveValue('john@test.com')
       expect(screen.getByPlaceholderText('Password')).toHaveValue(
+        'Password123!'
+      )
+      expect(screen.getByPlaceholderText('Confirm Password')).toHaveValue(
         'Password123!'
       )
     })
   })
 
   describe('User Interactions', () => {
+    it('should call setName when user types in the name field', () => {
+      render(<Login />)
+      const nameInput = screen.getByPlaceholderText('Name')
+      fireEvent.change(nameInput, { target: { value: 'John' } })
+      expect(mockSetName).toHaveBeenCalledWith('John')
+    })
+
     it('should call setEmail when user types in the email field', () => {
       render(<Login />)
       const emailInput = screen.getByPlaceholderText('Email')
@@ -89,23 +109,33 @@ describe('Login Component (Login State)', () => {
       expect(mockSetPassword).toHaveBeenCalledWith('pass123')
     })
 
-    it('should call onSubmitHandler when the Sign In button is clicked', () => {
+    it('should call setConfirmPassword when user types in the confirm password field', () => {
+      render(<Login />)
+      const confirmPasswordInput =
+        screen.getByPlaceholderText('Confirm Password')
+      fireEvent.change(confirmPasswordInput, { target: { value: 'pass123' } })
+      expect(mockSetConfirmPassword).toHaveBeenCalledWith('pass123')
+    })
+
+    it('should call onSubmitHandler when the Sign Up button is clicked', () => {
       mockAuthForm({
+        name: 'John',
         email: 'john@test.com',
         password: 'Password123!',
+        confirmPassword: 'Password123!',
       })
       render(<Login />)
 
-      const signInButton = screen.getByRole('button', { name: /Sign In/i })
-      fireEvent.click(signInButton)
+      const signUpButton = screen.getByRole('button', { name: /Sign Up/i })
+      fireEvent.click(signUpButton)
       expect(mockOnSubmitHandler).toHaveBeenCalledTimes(1)
     })
 
-    it('should call setCurrentState when the "Create account" link is clicked', () => {
+    it('should call setCurrentState when the "Login Here" link is clicked', () => {
       render(<Login />)
-      const createAccountLink = screen.getByText('Create account')
-      fireEvent.click(createAccountLink)
-      expect(mockSetCurrentState).toHaveBeenCalledWith('Sign Up')
+      const loginLink = screen.getByText('Login Here')
+      fireEvent.click(loginLink)
+      expect(mockSetCurrentState).toHaveBeenCalledWith('Login')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add unit and integration tests for the login flow across frontend and backend

## What's covered

**Frontend (Vitest + React Testing Library):**
- `Login.test.jsx` — 6 unit tests: rendering, input interactions, form submit, state toggle
- `Login.integration.test.jsx` — 3 integration tests: successful login, failed login, network error
- `useAuthForm.test.jsx` — 4 new login tests added to existing hook test file

**Backend (Jest + supertest):**
- `loginUser.test.js` — 5 unit tests: user not found, wrong password, bcrypt.compare args, token creation, catch block
- `userLogin.integration.test.js` — 3 integration tests: successful login with token verification, non-existent email, incorrect password

## Test plan
- [x] All frontend tests pass (`npx vitest run`)
- [x] All backend tests pass (`npm test`)
- [x] Existing signup tests unaffected by rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)