### PR TITLE
feat(tests): navbar+footer tests

### DIFF
--- a/frontend/src/components/Footer.test.jsx
+++ b/frontend/src/components/Footer.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import Footer from './Footer'
+import { assets } from '../assets/assets'
+
+describe('Footer', () => {
+  it('renders brand section with logo and description', () => {
+    const { container } = render(<Footer />)
+    const logo = container.querySelector('img')
+    expect(logo).toHaveAttribute('src', assets.logo)
+    expect(
+      screen.getByText(/Lorem ipsum dolor sit amet consectetur/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders COMPANY section with title and 4 items', () => {
+    render(<Footer />)
+    expect(screen.getByText('COMPANY')).toBeInTheDocument()
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('About Us')).toBeInTheDocument()
+    expect(screen.getByText('Delivery')).toBeInTheDocument()
+    expect(screen.getByText('Privacy Policy')).toBeInTheDocument()
+  })
+
+  it('renders GET IN TOUCH section with title, phone, and email', () => {
+    render(<Footer />)
+    expect(screen.getByText('GET IN TOUCH')).toBeInTheDocument()
+    expect(screen.getByText('+1-212-521-4569')).toBeInTheDocument()
+    expect(screen.getByText('contact@foreveryou.com')).toBeInTheDocument()
+  })
+
+  it('renders copyright text', () => {
+    render(<Footer />)
+    expect(
+      screen.getByText(/Copyright 2024@ forever\.com - All Right Reserved\./i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders sections in correct order', () => {
+    const { container } = render(<Footer />)
+    const headings = Array.from(container.querySelectorAll('p')).map((p) =>
+      p.textContent.trim()
+    )
+    const companyIdx = headings.indexOf('COMPANY')
+    const contactIdx = headings.indexOf('GET IN TOUCH')
+    const copyrightIdx = headings.findIndex((t) => t.startsWith('Copyright'))
+    expect(companyIdx).toBeGreaterThan(-1)
+    expect(contactIdx).toBeGreaterThan(companyIdx)
+    expect(copyrightIdx).toBeGreaterThan(contactIdx)
+  })
+})

--- a/frontend/src/components/Navbar.integration.test.jsx
+++ b/frontend/src/components/Navbar.integration.test.jsx
@@ -103,9 +103,7 @@ describe('Navbar Integration', () => {
 
     const paths = ['/collection', '/about', '/contact', '/']
     paths.forEach((path) => {
-      fireEvent.click(
-        container.querySelector(`img[src="${assets.menu_icon}"]`)
-      )
+      fireEvent.click(container.querySelector(`img[src="${assets.menu_icon}"]`))
       const link = sidebar.querySelector(`a[href="${path}"]`)
       fireEvent.click(link)
       expect(screen.getByTestId('location')).toHaveTextContent(path)

--- a/frontend/src/components/Navbar.integration.test.jsx
+++ b/frontend/src/components/Navbar.integration.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useState } from 'react'
 import {
   MemoryRouter,
   Routes,
@@ -8,6 +9,7 @@ import {
   useNavigate,
 } from 'react-router-dom'
 import Navbar from './Navbar'
+import SearchBar from './SearchBar'
 import { ShopContext } from '../context/ShopContext'
 import { assets } from '../assets/assets'
 
@@ -16,30 +18,50 @@ const LocationProbe = () => {
   return <div data-testid='location'>{loc.pathname}</div>
 }
 
-const NavigateBridge = ({ ctxOverrides = {}, children }) => {
+const ContextBridge = ({ ctxOverrides = {}, children }) => {
   const navigate = useNavigate()
+  const [showSearch, setShowSearch] = useState(
+    ctxOverrides.initialShowSearch ?? false
+  )
+  const [search, setSearch] = useState('')
   const value = {
-    setShowSearch: vi.fn(),
-    getCartCount: vi.fn(() => 0),
+    navigate,
+    showSearch,
+    setShowSearch,
+    search,
+    setSearch,
+    getCartCount: () => 0,
     token: '',
     setToken: vi.fn(),
     setCartItems: vi.fn(),
-    navigate,
     ...ctxOverrides,
   }
   return <ShopContext.Provider value={value}>{children}</ShopContext.Provider>
 }
 
-const renderNavbar = (ctxOverrides = {}, initialPath = '/') =>
+const renderWith = (children, { ctxOverrides = {}, initialPath = '/' } = {}) =>
   render(
     <MemoryRouter initialEntries={[initialPath]}>
-      <NavigateBridge ctxOverrides={ctxOverrides}>
-        <Navbar />
-      </NavigateBridge>
+      <ContextBridge ctxOverrides={ctxOverrides}>{children}</ContextBridge>
       <Routes>
         <Route path='*' element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>
+  )
+
+const renderNavbar = (ctxOverrides = {}, initialPath = '/') =>
+  renderWith(<Navbar />, { ctxOverrides, initialPath })
+
+const renderNavbarWithSearch = (
+  ctxOverrides = {},
+  initialPath = '/collection'
+) =>
+  renderWith(
+    <>
+      <Navbar />
+      <SearchBar />
+    </>,
+    { ctxOverrides, initialPath }
   )
 
 describe('Navbar Integration', () => {
@@ -94,6 +116,33 @@ describe('Navbar Integration', () => {
     renderNavbar({ token: 'abc123' })
     fireEvent.click(screen.getByText('Logout'))
     expect(screen.getByTestId('location')).toHaveTextContent('/login')
+  })
+
+  it('clicking Navbar search icon on /collection shows SearchBar input', () => {
+    const { container } = renderNavbarWithSearch({}, '/collection')
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument()
+    fireEvent.click(
+      container.querySelector(`img[src="${assets.search_icon}"]`)
+    )
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument()
+  })
+
+  it('clicking Navbar search icon on non-collection route does NOT show SearchBar input', () => {
+    const { container } = renderNavbarWithSearch({}, '/about')
+    fireEvent.click(
+      container.querySelector(`img[src="${assets.search_icon}"]`)
+    )
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument()
+  })
+
+  it('clicking cross icon in SearchBar hides input', () => {
+    const { container } = renderNavbarWithSearch(
+      { initialShowSearch: true },
+      '/collection'
+    )
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument()
+    fireEvent.click(container.querySelector(`img[src="${assets.cross_icon}"]`))
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument()
   })
 
   it('clicking each mobile sidebar NavLink navigates to correct path', () => {

--- a/frontend/src/components/Navbar.integration.test.jsx
+++ b/frontend/src/components/Navbar.integration.test.jsx
@@ -121,17 +121,13 @@ describe('Navbar Integration', () => {
   it('clicking Navbar search icon on /collection shows SearchBar input', () => {
     const { container } = renderNavbarWithSearch({}, '/collection')
     expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument()
-    fireEvent.click(
-      container.querySelector(`img[src="${assets.search_icon}"]`)
-    )
+    fireEvent.click(container.querySelector(`img[src="${assets.search_icon}"]`))
     expect(screen.getByPlaceholderText('Search')).toBeInTheDocument()
   })
 
   it('clicking Navbar search icon on non-collection route does NOT show SearchBar input', () => {
     const { container } = renderNavbarWithSearch({}, '/about')
-    fireEvent.click(
-      container.querySelector(`img[src="${assets.search_icon}"]`)
-    )
+    fireEvent.click(container.querySelector(`img[src="${assets.search_icon}"]`))
     expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/Navbar.integration.test.jsx
+++ b/frontend/src/components/Navbar.integration.test.jsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom'
+import Navbar from './Navbar'
+import { ShopContext } from '../context/ShopContext'
+import { assets } from '../assets/assets'
+
+const LocationProbe = () => {
+  const loc = useLocation()
+  return <div data-testid='location'>{loc.pathname}</div>
+}
+
+const NavigateBridge = ({ ctxOverrides = {}, children }) => {
+  const navigate = useNavigate()
+  const value = {
+    setShowSearch: vi.fn(),
+    getCartCount: vi.fn(() => 0),
+    token: '',
+    setToken: vi.fn(),
+    setCartItems: vi.fn(),
+    navigate,
+    ...ctxOverrides,
+  }
+  return <ShopContext.Provider value={value}>{children}</ShopContext.Provider>
+}
+
+const renderNavbar = (ctxOverrides = {}, initialPath = '/') =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <NavigateBridge ctxOverrides={ctxOverrides}>
+        <Navbar />
+      </NavigateBridge>
+      <Routes>
+        <Route path='*' element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('Navbar Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('clicking each desktop NavLink navigates to correct path', () => {
+    const { container } = renderNavbar()
+    const desktopNav = container.querySelector('ul')
+
+    const paths = ['/collection', '/about', '/contact', '/']
+    paths.forEach((path) => {
+      const link = desktopNav.querySelector(`a[href="${path}"]`)
+      fireEvent.click(link)
+      expect(screen.getByTestId('location')).toHaveTextContent(path)
+    })
+  })
+
+  it('clicking logo navigates to /', () => {
+    const { container } = renderNavbar({}, '/about')
+    expect(screen.getByTestId('location')).toHaveTextContent('/about')
+    const logoLink = container.querySelectorAll('a[href="/"]')[0]
+    fireEvent.click(logoLink)
+    expect(screen.getByTestId('location')).toHaveTextContent('/')
+  })
+
+  it('clicking cart Link navigates to /cart', () => {
+    const { container } = renderNavbar()
+    const cartLink = container.querySelector('a[href="/cart"]')
+    fireEvent.click(cartLink)
+    expect(screen.getByTestId('location')).toHaveTextContent('/cart')
+  })
+
+  it('clicking profile icon navigates to /login when no token', () => {
+    const { container } = renderNavbar({ token: '' })
+    const profileIcon = container.querySelector(
+      `img[src="${assets.profile_icon}"]`
+    )
+    fireEvent.click(profileIcon)
+    expect(screen.getByTestId('location')).toHaveTextContent('/login')
+  })
+
+  it('clicking Orders in dropdown navigates to /orders', () => {
+    renderNavbar({ token: 'abc123' })
+    fireEvent.click(screen.getByText('Orders'))
+    expect(screen.getByTestId('location')).toHaveTextContent('/orders')
+  })
+
+  it('clicking Logout navigates to /login', () => {
+    renderNavbar({ token: 'abc123' })
+    fireEvent.click(screen.getByText('Logout'))
+    expect(screen.getByTestId('location')).toHaveTextContent('/login')
+  })
+
+  it('clicking each mobile sidebar NavLink navigates to correct path', () => {
+    const { container } = renderNavbar()
+    fireEvent.click(container.querySelector(`img[src="${assets.menu_icon}"]`))
+    const sidebar = container.querySelector('.absolute.top-0.right-0')
+
+    const paths = ['/collection', '/about', '/contact', '/']
+    paths.forEach((path) => {
+      fireEvent.click(
+        container.querySelector(`img[src="${assets.menu_icon}"]`)
+      )
+      const link = sidebar.querySelector(`a[href="${path}"]`)
+      fireEvent.click(link)
+      expect(screen.getByTestId('location')).toHaveTextContent(path)
+    })
+  })
+})

--- a/frontend/src/components/Navbar.test.jsx
+++ b/frontend/src/components/Navbar.test.jsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import Navbar from './Navbar'
+import { ShopContext } from '../context/ShopContext'
+import { assets } from '../assets/assets'
+
+const renderNavbar = (ctxOverrides = {}) => {
+  const ctx = {
+    setShowSearch: vi.fn(),
+    getCartCount: vi.fn(() => 0),
+    navigate: vi.fn(),
+    token: '',
+    setToken: vi.fn(),
+    setCartItems: vi.fn(),
+    ...ctxOverrides,
+  }
+  const result = render(
+    <MemoryRouter>
+      <ShopContext.Provider value={ctx}>
+        <Navbar />
+      </ShopContext.Provider>
+    </MemoryRouter>
+  )
+  return { ...result, ctx }
+}
+
+describe('Navbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('renders logo, 4 desktop nav links with correct paths, and search/profile/cart/menu icons', () => {
+    const { container } = renderNavbar()
+
+    const logoLink = container.querySelector('a[href="/"]')
+    expect(logoLink).toBeInTheDocument()
+    expect(logoLink.querySelector('img')).toHaveAttribute('src', assets.logo)
+
+    const desktopNav = container.querySelector('ul')
+    const desktopLinks = Array.from(desktopNav.querySelectorAll('a')).map((a) =>
+      a.getAttribute('href')
+    )
+    expect(desktopLinks).toEqual(['/', '/collection', '/about', '/contact'])
+    expect(desktopNav).toHaveTextContent('HOME')
+    expect(desktopNav).toHaveTextContent('COLLECTION')
+    expect(desktopNav).toHaveTextContent('ABOUT')
+    expect(desktopNav).toHaveTextContent('CONTACT')
+
+    const imgSrcs = Array.from(container.querySelectorAll('img')).map((el) =>
+      el.getAttribute('src')
+    )
+    expect(imgSrcs).toContain(assets.search_icon)
+    expect(imgSrcs).toContain(assets.profile_icon)
+    expect(imgSrcs).toContain(assets.cart_icon)
+    expect(imgSrcs).toContain(assets.menu_icon)
+  })
+
+  it('clicking search icon calls setShowSearch(true)', () => {
+    const { container, ctx } = renderNavbar()
+    const searchIcon = container.querySelector(
+      `img[src="${assets.search_icon}"]`
+    )
+    fireEvent.click(searchIcon)
+    expect(ctx.setShowSearch).toHaveBeenCalledWith(true)
+  })
+
+  it('does not render profile dropdown when no token', () => {
+    renderNavbar({ token: '' })
+    expect(screen.queryByText('My Profile')).not.toBeInTheDocument()
+    expect(screen.queryByText('Orders')).not.toBeInTheDocument()
+    expect(screen.queryByText('Logout')).not.toBeInTheDocument()
+  })
+
+  it('clicking profile icon does NOT navigate when token present', () => {
+    const { container, ctx } = renderNavbar({ token: 'abc123' })
+    const profileIcon = container.querySelector(
+      `img[src="${assets.profile_icon}"]`
+    )
+    fireEvent.click(profileIcon)
+    expect(ctx.navigate).not.toHaveBeenCalled()
+  })
+
+  it('renders profile dropdown (My Profile, Orders, Logout) when token present', () => {
+    renderNavbar({ token: 'abc123' })
+    expect(screen.getByText('My Profile')).toBeInTheDocument()
+    expect(screen.getByText('Orders')).toBeInTheDocument()
+    expect(screen.getByText('Logout')).toBeInTheDocument()
+  })
+
+  it('clicking Logout: navigates to /login, removes token from localStorage, clears token, clears cart', () => {
+    localStorage.setItem('token', 'abc123')
+    const { ctx } = renderNavbar({ token: 'abc123' })
+
+    fireEvent.click(screen.getByText('Logout'))
+
+    expect(ctx.navigate).toHaveBeenCalledWith('/login')
+    expect(localStorage.getItem('token')).toBeNull()
+    expect(ctx.setToken).toHaveBeenCalledWith('')
+    expect(ctx.setCartItems).toHaveBeenCalledWith({})
+  })
+
+  it('cart link points to /cart and displays getCartCount value', () => {
+    const { container } = renderNavbar({ getCartCount: vi.fn(() => 7) })
+    const cartLink = container.querySelector('a[href="/cart"]')
+    expect(cartLink).toBeInTheDocument()
+    expect(cartLink.querySelector('img')).toHaveAttribute(
+      'src',
+      assets.cart_icon
+    )
+    expect(cartLink).toHaveTextContent('7')
+  })
+
+  it('clicking menu icon opens mobile sidebar', () => {
+    const { container } = renderNavbar()
+    const sidebar = container.querySelector('.absolute.top-0.right-0')
+    expect(sidebar.className).toContain('w-0')
+
+    const menuIcon = container.querySelector(`img[src="${assets.menu_icon}"]`)
+    fireEvent.click(menuIcon)
+
+    expect(sidebar.className).toContain('w-full')
+  })
+
+  it('mobile sidebar renders 4 nav links with correct paths', () => {
+    const { container } = renderNavbar()
+    const sidebar = container.querySelector('.absolute.top-0.right-0')
+    const links = Array.from(sidebar.querySelectorAll('a')).map((a) =>
+      a.getAttribute('href')
+    )
+    expect(links).toEqual(['/', '/collection', '/about', '/contact'])
+
+    expect(sidebar).toHaveTextContent('HOME')
+    expect(sidebar).toHaveTextContent('COLLECTION')
+    expect(sidebar).toHaveTextContent('ABOUT')
+    expect(sidebar).toHaveTextContent('CONTACT')
+  })
+
+  it('clicking Back closes mobile sidebar', () => {
+    const { container } = renderNavbar()
+    fireEvent.click(container.querySelector(`img[src="${assets.menu_icon}"]`))
+    const sidebar = container.querySelector('.absolute.top-0.right-0')
+    expect(sidebar.className).toContain('w-full')
+
+    fireEvent.click(screen.getByText('Back'))
+    expect(sidebar.className).toContain('w-0')
+  })
+
+  it('clicking a sidebar nav link closes the sidebar', () => {
+    const { container } = renderNavbar()
+    fireEvent.click(container.querySelector(`img[src="${assets.menu_icon}"]`))
+    const sidebar = container.querySelector('.absolute.top-0.right-0')
+    expect(sidebar.className).toContain('w-full')
+
+    const collectionLink = sidebar.querySelector('a[href="/collection"]')
+    fireEvent.click(collectionLink)
+    expect(sidebar.className).toContain('w-0')
+  })
+})

--- a/frontend/src/components/SearchBar.test.jsx
+++ b/frontend/src/components/SearchBar.test.jsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import SearchBar from './SearchBar'
+import { ShopContext } from '../context/ShopContext'
+import { assets } from '../assets/assets'
+
+const renderSearchBar = (ctxOverrides = {}, path = '/collection') => {
+  const ctx = {
+    search: '',
+    setSearch: vi.fn(),
+    showSearch: true,
+    setShowSearch: vi.fn(),
+    ...ctxOverrides,
+  }
+  const result = render(
+    <MemoryRouter initialEntries={[path]}>
+      <ShopContext.Provider value={ctx}>
+        <SearchBar />
+      </ShopContext.Provider>
+    </MemoryRouter>
+  )
+  return { ...result, ctx }
+}
+
+describe('SearchBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders input and cross icon when showSearch=true AND on /collection', () => {
+    const { container } = renderSearchBar({ showSearch: true }, '/collection')
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument()
+    expect(
+      container.querySelector(`img[src="${assets.cross_icon}"]`)
+    ).toBeInTheDocument()
+  })
+
+  it('does NOT render when showSearch=false on /collection', () => {
+    renderSearchBar({ showSearch: false }, '/collection')
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument()
+  })
+
+  it('does NOT render when showSearch=true but on non-collection route', () => {
+    renderSearchBar({ showSearch: true }, '/about')
+    expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument()
+  })
+
+  it('displays current search value from context', () => {
+    renderSearchBar({ search: 'shirt' }, '/collection')
+    expect(screen.getByPlaceholderText('Search')).toHaveValue('shirt')
+  })
+
+  it('typing in input calls setSearch with value', () => {
+    const { ctx } = renderSearchBar({}, '/collection')
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'jeans' },
+    })
+    expect(ctx.setSearch).toHaveBeenCalledWith('jeans')
+  })
+
+  it('clicking cross icon calls setShowSearch(false)', () => {
+    const { container, ctx } = renderSearchBar({}, '/collection')
+    fireEvent.click(container.querySelector(`img[src="${assets.cross_icon}"]`))
+    expect(ctx.setShowSearch).toHaveBeenCalledWith(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add unit tests for `Navbar`, `Footer`, and `SearchBar` components using Vitest + React Testing Library
- Add integration tests for `Navbar`

## Test plan

- [x] All tests pass (`npm run test` in `frontend/`)
- [x] No regressions in existing test suite
- [x] Prettier formatting fixed