### PR TITLE
feat(tests): product tests

### DIFF
--- a/backend/controllers/productController.test.js
+++ b/backend/controllers/productController.test.js
@@ -1,0 +1,415 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// ─── Mock setup ───────────────────────────────────────────────────────────────
+
+const mockSave = jest.fn()
+const MockProductModel = jest.fn(() => ({ save: mockSave }))
+MockProductModel.find = jest.fn()
+MockProductModel.findById = jest.fn()
+MockProductModel.findByIdAndDelete = jest.fn()
+MockProductModel.insertMany = jest.fn()
+
+jest.unstable_mockModule('../models/productModel.js', () => ({
+  default: MockProductModel,
+}))
+
+jest.unstable_mockModule('cloudinary', () => ({
+  v2: {
+    uploader: { upload: jest.fn() },
+  },
+}))
+
+// ─── Dynamic imports ──────────────────────────────────────────────────────────
+
+const {
+  addProduct,
+  listProduct,
+  removeProduct,
+  singleProduct,
+  addProductsBulk,
+} = await import('./productController.js')
+const { v2: cloudinary } = await import('cloudinary')
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeRes = () => ({ json: jest.fn(), status: jest.fn().mockReturnThis() })
+
+const makeAddReq = (overrides = {}) => ({
+  body: {
+    name: 'Test Shirt',
+    description: 'A shirt',
+    price: '49',
+    category: 'Men',
+    subCategory: 'Topwear',
+    sizes: JSON.stringify(['S', 'M', 'L']),
+    bestSeller: 'false',
+    ...overrides,
+  },
+  files: {
+    image1: [{ path: '/tmp/img1.jpg' }],
+    image2: [{ path: '/tmp/img2.jpg' }],
+  },
+})
+
+// ─── addProduct ───────────────────────────────────────────────────────────────
+
+describe('addProduct', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('uploads provided images to cloudinary and saves product', async () => {
+    cloudinary.uploader.upload
+      .mockResolvedValueOnce({ secure_url: 'https://cdn/img1.jpg' })
+      .mockResolvedValueOnce({ secure_url: 'https://cdn/img2.jpg' })
+    mockSave.mockResolvedValue()
+
+    const res = makeRes()
+    await addProduct(makeAddReq(), res)
+
+    expect(cloudinary.uploader.upload).toHaveBeenCalledTimes(2)
+    expect(mockSave).toHaveBeenCalledTimes(1)
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Product Added',
+    })
+  })
+
+  it('coerces price to Number', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+    mockSave.mockResolvedValue()
+
+    const res = makeRes()
+    await addProduct(makeAddReq({ price: '99' }), res)
+
+    const savedData = MockProductModel.mock.calls[0][0]
+    expect(savedData.price).toBe(99)
+    expect(typeof savedData.price).toBe('number')
+  })
+
+  it('coerces bestSeller string "true" to boolean true', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+    mockSave.mockResolvedValue()
+
+    const res = makeRes()
+    await addProduct(makeAddReq({ bestSeller: 'true' }), res)
+
+    const savedData = MockProductModel.mock.calls[0][0]
+    expect(savedData.bestSeller).toBe(true)
+  })
+
+  it('parses sizes from JSON string', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+    mockSave.mockResolvedValue()
+
+    const res = makeRes()
+    await addProduct(makeAddReq({ sizes: JSON.stringify(['XS', 'XL']) }), res)
+
+    const savedData = MockProductModel.mock.calls[0][0]
+    expect(savedData.sizes).toEqual(['XS', 'XL'])
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    cloudinary.uploader.upload.mockRejectedValue(
+      new Error('Cloudinary unavailable')
+    )
+
+    const res = makeRes()
+    await addProduct(makeAddReq(), res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Cloudinary unavailable',
+    })
+  })
+})
+
+// ─── listProduct ──────────────────────────────────────────────────────────────
+
+describe('listProduct', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns all products with success: true', async () => {
+    const products = [{ _id: 'p1', name: 'Shirt' }]
+    MockProductModel.find.mockResolvedValue(products)
+
+    const res = makeRes()
+    await listProduct({}, res)
+
+    expect(MockProductModel.find).toHaveBeenCalledWith({})
+    expect(res.json).toHaveBeenCalledWith({ success: true, products })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    MockProductModel.find.mockRejectedValue(new Error('DB error'))
+
+    const res = makeRes()
+    await listProduct({}, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'DB error',
+    })
+  })
+})
+
+// ─── removeProduct ────────────────────────────────────────────────────────────
+
+describe('removeProduct', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('calls findByIdAndDelete with req.body.id and returns success', async () => {
+    MockProductModel.findByIdAndDelete.mockResolvedValue()
+
+    const res = makeRes()
+    await removeProduct({ body: { id: 'p42' } }, res)
+
+    expect(MockProductModel.findByIdAndDelete).toHaveBeenCalledWith('p42')
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Product Removed',
+    })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    MockProductModel.findByIdAndDelete.mockRejectedValue(new Error('DB error'))
+
+    const res = makeRes()
+    await removeProduct({ body: { id: 'bad-id' } }, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'DB error',
+    })
+  })
+})
+
+// ─── singleProduct ────────────────────────────────────────────────────────────
+
+describe('singleProduct', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns product by id with success: true', async () => {
+    const product = { _id: 'p1', name: 'Shirt' }
+    MockProductModel.findById.mockResolvedValue(product)
+
+    const res = makeRes()
+    await singleProduct({ body: { productId: 'p1' } }, res)
+
+    expect(MockProductModel.findById).toHaveBeenCalledWith('p1')
+    expect(res.json).toHaveBeenCalledWith({ success: true, product })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    MockProductModel.findById.mockRejectedValue(new Error('DB error'))
+
+    const res = makeRes()
+    await singleProduct({ body: { productId: 'bad-id' } }, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'DB error',
+    })
+  })
+})
+
+// ─── addProductsBulk ──────────────────────────────────────────────────────────
+
+describe('addProductsBulk', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  const makeBulkReq = (productsData, files = []) => ({
+    body: { products: JSON.stringify(productsData) },
+    files,
+  })
+
+  it('returns 400 when products data is empty array', async () => {
+    const res = makeRes()
+    await addProductsBulk(makeBulkReq([]), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Invalid products data',
+    })
+  })
+
+  it('returns 400 when products field is not an array', async () => {
+    const res = makeRes()
+    await addProductsBulk(
+      { body: { products: JSON.stringify({ name: 'x' }) }, files: [] },
+      res
+    )
+
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  it('uploads images scoped by product index fieldname prefix', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+    MockProductModel.insertMany.mockResolvedValue()
+
+    const products = [
+      {
+        name: 'A',
+        description: 'd',
+        price: '10',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: ['S'],
+        bestSeller: false,
+      },
+    ]
+    const files = [
+      { fieldname: 'product_0_image1', path: '/tmp/a.jpg' },
+      { fieldname: 'other_field', path: '/tmp/b.jpg' },
+    ]
+
+    const res = makeRes()
+    await addProductsBulk(makeBulkReq(products, files), res)
+
+    expect(cloudinary.uploader.upload).toHaveBeenCalledTimes(1)
+    expect(cloudinary.uploader.upload).toHaveBeenCalledWith('/tmp/a.jpg', {
+      resource_type: 'image',
+    })
+  })
+
+  it('saves all products via insertMany and returns success', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+    MockProductModel.insertMany.mockResolvedValue()
+
+    const products = [
+      {
+        name: 'A',
+        description: 'd',
+        price: '10',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: ['S'],
+        bestSeller: false,
+      },
+      {
+        name: 'B',
+        description: 'd',
+        price: '20',
+        category: 'Women',
+        subCategory: 'Top',
+        sizes: ['M'],
+        bestSeller: true,
+      },
+    ]
+
+    const res = makeRes()
+    await addProductsBulk(makeBulkReq(products, []), res)
+
+    expect(MockProductModel.insertMany).toHaveBeenCalledTimes(1)
+    expect(MockProductModel.insertMany.mock.calls[0][0]).toHaveLength(2)
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Products Added Successfully',
+    })
+  })
+
+  it('coerces bestSeller from string "true" and boolean true', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+    MockProductModel.insertMany.mockResolvedValue()
+
+    const products = [
+      {
+        name: 'A',
+        description: 'd',
+        price: '10',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: ['S'],
+        bestSeller: 'true',
+      },
+      {
+        name: 'B',
+        description: 'd',
+        price: '20',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: ['S'],
+        bestSeller: true,
+      },
+    ]
+
+    const res = makeRes()
+    await addProductsBulk(makeBulkReq(products, []), res)
+
+    const saved = MockProductModel.insertMany.mock.calls[0][0]
+    expect(saved[0].bestSeller).toBe(true)
+    expect(saved[1].bestSeller).toBe(true)
+  })
+
+  it('accepts sizes as array or JSON string', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+    MockProductModel.insertMany.mockResolvedValue()
+
+    const products = [
+      {
+        name: 'A',
+        description: 'd',
+        price: '10',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: ['S', 'M'],
+        bestSeller: false,
+      },
+      {
+        name: 'B',
+        description: 'd',
+        price: '20',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: JSON.stringify(['L', 'XL']),
+        bestSeller: false,
+      },
+    ]
+
+    const res = makeRes()
+    await addProductsBulk(makeBulkReq(products, []), res)
+
+    const saved = MockProductModel.insertMany.mock.calls[0][0]
+    expect(saved[0].sizes).toEqual(['S', 'M'])
+    expect(saved[1].sizes).toEqual(['L', 'XL'])
+  })
+
+  it('returns 500 with error message on failure', async () => {
+    cloudinary.uploader.upload.mockRejectedValue(new Error('Upload failed'))
+
+    const products = [
+      {
+        name: 'A',
+        description: 'd',
+        price: '10',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: ['S'],
+        bestSeller: false,
+      },
+    ]
+    const files = [{ fieldname: 'product_0_image1', path: '/tmp/a.jpg' }]
+
+    const res = makeRes()
+    await addProductsBulk(makeBulkReq(products, files), res)
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Upload failed',
+    })
+  })
+})

--- a/backend/models/productModel.js
+++ b/backend/models/productModel.js
@@ -4,10 +4,24 @@ const productSchema = new mongoose.Schema({
   name: { type: String, required: true },
   description: { type: String, required: true },
   price: { type: Number, required: true },
-  image: { type: Array, required: true },
+  image: {
+    type: Array,
+    required: true,
+    validate: {
+      validator: (v) => v.length > 0,
+      message: 'image must not be empty',
+    },
+  },
   category: { type: String, required: true },
   subCategory: { type: String, required: true },
-  sizes: { type: Array, required: true },
+  sizes: {
+    type: Array,
+    required: true,
+    validate: {
+      validator: (v) => v.length > 0,
+      message: 'sizes must not be empty',
+    },
+  },
   bestSeller: { type: Boolean },
   date: { type: Number, required: true },
 })

--- a/backend/models/productModel.test.js
+++ b/backend/models/productModel.test.js
@@ -1,0 +1,88 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import productModel from './productModel.js'
+
+let mongoServer
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create()
+  await mongoose.connect(mongoServer.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+afterEach(async () => {
+  await productModel.deleteMany({})
+})
+
+const validProduct = {
+  name: 'Test Shirt',
+  description: 'A great shirt',
+  price: 49,
+  image: ['img1.png'],
+  category: 'Men',
+  subCategory: 'Topwear',
+  sizes: ['S', 'M', 'L'],
+  date: Date.now(),
+}
+
+describe('productModel schema', () => {
+  it('saves a valid product successfully', async () => {
+    const product = new productModel(validProduct)
+    const saved = await product.save()
+    expect(saved._id).toBeDefined()
+  })
+
+  it.each([
+    ['name', { ...validProduct, name: undefined }],
+    ['description', { ...validProduct, description: undefined }],
+    ['price', { ...validProduct, price: undefined }],
+    ['image', { ...validProduct, image: undefined }],
+    ['image', { ...validProduct, image: [] }],
+    ['category', { ...validProduct, category: undefined }],
+    ['subCategory', { ...validProduct, subCategory: undefined }],
+    ['sizes', { ...validProduct, sizes: undefined }],
+    ['sizes', { ...validProduct, sizes: [] }],
+    ['date', { ...validProduct, date: undefined }],
+  ])(
+    'throws validation error when %s is missing or empty',
+    async (field, data) => {
+      const product = new productModel(data)
+      await expect(product.save()).rejects.toThrow(new RegExp(field))
+    }
+  )
+
+  it('saves without bestSeller — field is optional', async () => {
+    const product = new productModel({
+      name: validProduct.name,
+      description: validProduct.description,
+      price: validProduct.price,
+      image: validProduct.image,
+      category: validProduct.category,
+      subCategory: validProduct.subCategory,
+      sizes: validProduct.sizes,
+      date: validProduct.date,
+    })
+    const saved = await product.save()
+    expect(saved._id).toBeDefined()
+    expect(saved.bestSeller).toBeUndefined()
+  })
+
+  it('stores price as Number and date as Number', async () => {
+    const product = new productModel(validProduct)
+    const saved = await product.save()
+    expect(typeof saved.price).toBe('number')
+    expect(typeof saved.date).toBe('number')
+  })
+})

--- a/backend/routes/productRoute.integration.test.js
+++ b/backend/routes/productRoute.integration.test.js
@@ -1,0 +1,250 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+
+// ─── Mock cloudinary before any dynamic imports ───────────────────────────────
+
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('cloudinary', () => ({
+  v2: {
+    uploader: { upload: jest.fn() },
+  },
+}))
+
+const { v2: cloudinary } = await import('cloudinary')
+const { default: productRouter } = await import('./productRoute.js')
+const { default: productModel } = await import('../models/productModel.js')
+
+// ─── Test app ─────────────────────────────────────────────────────────────────
+
+const app = express()
+app.use(express.json())
+app.use('/api/product', productRouter)
+
+// ─── Database setup ───────────────────────────────────────────────────────────
+
+let mongoServer
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'test-secret'
+  mongoServer = await MongoMemoryServer.create()
+  await mongoose.connect(mongoServer.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+afterEach(async () => {
+  await productModel.deleteMany({})
+  jest.clearAllMocks()
+})
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const adminToken = () =>
+  jwt.sign({ id: 'admin-id', role: 'admin' }, process.env.JWT_SECRET, {
+    expiresIn: '1d',
+  })
+
+const userToken = () =>
+  jwt.sign({ id: 'user-id', role: 'user' }, process.env.JWT_SECRET, {
+    expiresIn: '1d',
+  })
+
+const seedProduct = (overrides = {}) =>
+  productModel.create({
+    name: 'Test Shirt',
+    description: 'A shirt',
+    price: 49,
+    image: ['img1.png'],
+    category: 'Men',
+    subCategory: 'Topwear',
+    sizes: ['S', 'M'],
+    date: Date.now(),
+    ...overrides,
+  })
+
+// ─── GET /api/product/list ────────────────────────────────────────────────────
+
+describe('GET /api/product/list', () => {
+  it('returns all products with success: true', async () => {
+    await seedProduct({ name: 'Shirt A' })
+    await seedProduct({ name: 'Shirt B' })
+
+    const res = await request(app).get('/api/product/list')
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.products).toHaveLength(2)
+    expect(res.body.products.map((p) => p.name)).toEqual(
+      expect.arrayContaining(['Shirt A', 'Shirt B'])
+    )
+  })
+})
+
+// ─── POST /api/product/single ─────────────────────────────────────────────────
+
+describe('POST /api/product/single', () => {
+  it('returns product by id with success: true', async () => {
+    const product = await seedProduct({ name: 'Solo Shirt' })
+
+    const res = await request(app)
+      .post('/api/product/single')
+      .send({ productId: product._id.toString() })
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.product.name).toBe('Solo Shirt')
+  })
+
+  // NOTE: when productId does not exist, mongoose findById returns null without
+  // throwing — controller responds { success: true, product: null } instead of
+  // a 404. Known gap in controller logic; no test asserts this broken behavior.
+})
+
+// ─── POST /api/product/remove ─────────────────────────────────────────────────
+
+describe('POST /api/product/remove', () => {
+  it('removes product and returns success: true', async () => {
+    const product = await seedProduct()
+
+    const res = await request(app)
+      .post('/api/product/remove')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ id: product._id.toString() })
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.message).toBe('Product Removed')
+    expect(await productModel.findById(product._id)).toBeNull()
+  })
+
+  it('returns 401 without token', async () => {
+    const product = await seedProduct()
+
+    const res = await request(app)
+      .post('/api/product/remove')
+      .send({ id: product._id.toString() })
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+
+  it('returns 403 with non-admin token', async () => {
+    const product = await seedProduct()
+
+    const res = await request(app)
+      .post('/api/product/remove')
+      .set('Authorization', `Bearer ${userToken()}`)
+      .send({ id: product._id.toString() })
+
+    expect(res.status).toBe(403)
+    expect(res.body.success).toBe(false)
+  })
+})
+
+// ─── POST /api/product/add ────────────────────────────────────────────────────
+
+describe('POST /api/product/add', () => {
+  it('adds product and returns success: true', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+
+    const res = await request(app)
+      .post('/api/product/add')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .field('name', 'New Jacket')
+      .field('description', 'A jacket')
+      .field('price', '99')
+      .field('category', 'Men')
+      .field('subCategory', 'Outerwear')
+      .field('sizes', JSON.stringify(['M', 'L']))
+      .field('bestSeller', 'false')
+      .attach('image1', Buffer.from('fake-image'), 'image1.jpg')
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.message).toBe('Product Added')
+    expect(await productModel.findOne({ name: 'New Jacket' })).not.toBeNull()
+  })
+
+  it('returns 401 without token', async () => {
+    const res = await request(app)
+      .post('/api/product/add')
+      .field('name', 'New Jacket')
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+})
+
+// ─── POST /api/product/add-bulk ───────────────────────────────────────────────
+
+describe('POST /api/product/add-bulk', () => {
+  it('adds multiple products and returns success: true', async () => {
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cdn/img.jpg',
+    })
+
+    const products = [
+      {
+        name: 'Bulk A',
+        description: 'desc',
+        price: '10',
+        category: 'Men',
+        subCategory: 'Top',
+        sizes: ['S'],
+        bestSeller: false,
+      },
+      {
+        name: 'Bulk B',
+        description: 'desc',
+        price: '20',
+        category: 'Women',
+        subCategory: 'Top',
+        sizes: ['M'],
+        bestSeller: false,
+      },
+    ]
+
+    const res = await request(app)
+      .post('/api/product/add-bulk')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .field('products', JSON.stringify(products))
+      .attach('product_0_image1', Buffer.from('fake-image'), 'p0img1.jpg')
+      .attach('product_1_image1', Buffer.from('fake-image'), 'p1img1.jpg')
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.message).toBe('Products Added Successfully')
+    expect(await productModel.countDocuments()).toBe(2)
+  })
+
+  it('returns 400 for invalid products data', async () => {
+    const res = await request(app)
+      .post('/api/product/add-bulk')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .field('products', JSON.stringify([]))
+
+    expect(res.status).toBe(400)
+    expect(res.body.success).toBe(false)
+  })
+
+  it('returns 401 without token', async () => {
+    const res = await request(app)
+      .post('/api/product/add-bulk')
+      .field('products', JSON.stringify([]))
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+})

--- a/frontend/src/components/ProductItem.test.jsx
+++ b/frontend/src/components/ProductItem.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import ProductItem from './ProductItem'
+import { ShopContext } from '../context/ShopContext'
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ to, children, className }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+const renderItem = (props) =>
+  render(
+    <ShopContext.Provider value={{ currency: '$' }}>
+      <ProductItem {...props} />
+    </ShopContext.Provider>
+  )
+
+describe('ProductItem Component', () => {
+  const defaultProps = {
+    id: 'p42',
+    name: 'Cool Jacket',
+    price: 89,
+    image: ['jacket.png', 'jacket2.png'],
+  }
+
+  it('renders product name and price with currency symbol', () => {
+    renderItem(defaultProps)
+    expect(screen.getByText('Cool Jacket')).toBeInTheDocument()
+    expect(screen.getByText('$89')).toBeInTheDocument()
+  })
+
+  it('link points to /product/:id', () => {
+    renderItem(defaultProps)
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/product/p42')
+  })
+
+  it('renders first image from image array', () => {
+    const { container } = renderItem(defaultProps)
+    const img = container.querySelector('img')
+    expect(img).toHaveAttribute('src', 'jacket.png')
+  })
+})

--- a/frontend/src/components/RelatedProduct.test.jsx
+++ b/frontend/src/components/RelatedProduct.test.jsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import RelatedProduct from './RelatedProduct'
+import { ShopContext } from '../context/ShopContext'
+
+vi.mock('./Title', () => ({
+  default: ({ text1, text2 }) => (
+    <div data-testid='title'>
+      {text1} {text2}
+    </div>
+  ),
+}))
+
+vi.mock('./ProductItem', () => ({
+  default: ({ id, name, price }) => (
+    <div data-testid='product-item' data-id={id}>
+      {name} - {price}
+    </div>
+  ),
+}))
+
+const makeProduct = (i, category = 'Men', subCategory = 'Topwear') => ({
+  _id: `id-${i}`,
+  name: `Product ${i}`,
+  price: 10 + i,
+  image: [`img-${i}.png`],
+  category,
+  subCategory,
+})
+
+const renderRelated = (products, category = 'Men', subCategory = 'Topwear') =>
+  render(
+    <ShopContext.Provider value={{ products }}>
+      <RelatedProduct category={category} subCategory={subCategory} />
+    </ShopContext.Provider>
+  )
+
+describe('RelatedProduct Component', () => {
+  it('renders Title with RELATED PRODUCTS', () => {
+    renderRelated([])
+    expect(screen.getByTestId('title')).toHaveTextContent('RELATED PRODUCTS')
+  })
+
+  it('renders only products matching both category and subCategory', () => {
+    const products = [
+      makeProduct(1, 'Men', 'Topwear'),
+      makeProduct(2, 'Women', 'Topwear'),
+      makeProduct(3, 'Men', 'Bottomwear'),
+      makeProduct(4, 'Men', 'Topwear'),
+    ]
+    renderRelated(products, 'Men', 'Topwear')
+    const items = screen.getAllByTestId('product-item')
+    expect(items).toHaveLength(2)
+    expect(items[0]).toHaveAttribute('data-id', 'id-1')
+    expect(items[1]).toHaveAttribute('data-id', 'id-4')
+  })
+
+  it('renders nothing when no products match', () => {
+    const products = [
+      makeProduct(1, 'Women', 'Topwear'),
+      makeProduct(2, 'Men', 'Bottomwear'),
+    ]
+    renderRelated(products, 'Men', 'Topwear')
+    expect(screen.queryByTestId('product-item')).not.toBeInTheDocument()
+  })
+
+  it('renders all matches when 5 or fewer', () => {
+    const products = Array.from({ length: 4 }, (_, i) => makeProduct(i))
+    renderRelated(products)
+    expect(screen.getAllByTestId('product-item')).toHaveLength(4)
+  })
+
+  it('limits to 5 when more than 5 match', () => {
+    const products = Array.from({ length: 8 }, (_, i) => makeProduct(i))
+    renderRelated(products)
+    expect(screen.getAllByTestId('product-item')).toHaveLength(5)
+  })
+
+  it('updates rendered products when context products change', () => {
+    const initial = [makeProduct(1)]
+    const { rerender } = render(
+      <ShopContext.Provider value={{ products: initial }}>
+        <RelatedProduct category='Men' subCategory='Topwear' />
+      </ShopContext.Provider>
+    )
+    expect(screen.getAllByTestId('product-item')).toHaveLength(1)
+
+    const updated = Array.from({ length: 3 }, (_, i) => makeProduct(i + 10))
+    rerender(
+      <ShopContext.Provider value={{ products: updated }}>
+        <RelatedProduct category='Men' subCategory='Topwear' />
+      </ShopContext.Provider>
+    )
+    expect(screen.getAllByTestId('product-item')).toHaveLength(3)
+  })
+})

--- a/frontend/src/pages/Product.integration.test.jsx
+++ b/frontend/src/pages/Product.integration.test.jsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { toast } from 'react-toastify'
+import Product from './Product'
+import { ShopContext } from '../context/ShopContext'
+
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const LocationProbe = () => {
+  const loc = useLocation()
+  return <div data-testid='location'>{loc.pathname}</div>
+}
+
+const makeProduct = (id, category = 'Men', subCategory = 'Topwear') => ({
+  _id: id,
+  name: `Product ${id}`,
+  price: 50,
+  description: 'Test description',
+  category,
+  subCategory,
+  sizes: ['S', 'M', 'L'],
+  image: [`${id}.png`],
+})
+
+const addToCart = vi.fn((_itemId, size) => {
+  if (!size) toast.error('Select product size!')
+})
+
+// ShopContext.Provider with manual value instead of real ShopContextProvider:
+// Product.jsx's useEffect depends only on [productId], not [products]. The real provider
+// loads products async via axios — by the time they arrive, useEffect won't re-run and
+// productData stays false. Pre-loaded manual value is the only way to render synchronously.
+const renderProduct = (products, startPath = '/product/p1') =>
+  render(
+    <MemoryRouter initialEntries={[startPath]}>
+      <ShopContext.Provider value={{ products, currency: '$', addToCart }}>
+        <Routes>
+          <Route path='/product/:productId' element={<Product />} />
+        </Routes>
+        <LocationProbe />
+      </ShopContext.Provider>
+    </MemoryRouter>
+  )
+
+describe('Product Page Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders RelatedProduct and ProductItem cards for matching products', () => {
+    const products = [
+      makeProduct('p1'),
+      makeProduct('p2'),
+      makeProduct('p3'),
+      makeProduct('p4', 'Women', 'Topwear'),
+    ]
+    const { container } = renderProduct(products)
+
+    expect(
+      screen.getByRole('heading', { name: 'Product p1' })
+    ).toBeInTheDocument()
+
+    // p2 and p3 match Men/Topwear → appear as related links; p4 does not
+    expect(container.querySelector('a[href="/product/p2"]')).toBeInTheDocument()
+    expect(container.querySelector('a[href="/product/p3"]')).toBeInTheDocument()
+    expect(
+      container.querySelector('a[href="/product/p4"]')
+    ).not.toBeInTheDocument()
+  })
+
+  it('clicking a related ProductItem navigates to that product route', async () => {
+    const products = [makeProduct('p1'), makeProduct('p2')]
+    renderProduct(products)
+
+    fireEvent.click(screen.getByText('Product p2'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/product/p2')
+    })
+  })
+
+  it('selecting a size and clicking ADD TO CART does not show size error', () => {
+    renderProduct([makeProduct('p1')])
+
+    fireEvent.click(screen.getByRole('button', { name: 'S' }))
+    fireEvent.click(screen.getByRole('button', { name: 'ADD TO CART' }))
+
+    expect(toast.error).not.toHaveBeenCalledWith('Select product size!')
+  })
+
+  it('clicking ADD TO CART without selecting a size shows error toast', () => {
+    renderProduct([makeProduct('p1')])
+
+    fireEvent.click(screen.getByRole('button', { name: 'ADD TO CART' }))
+
+    expect(toast.error).toHaveBeenCalledWith('Select product size!')
+  })
+})

--- a/frontend/src/pages/Product.test.jsx
+++ b/frontend/src/pages/Product.test.jsx
@@ -1,0 +1,151 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Product from './Product'
+import { ShopContext } from '../context/ShopContext'
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ productId: 'p1' }),
+}))
+
+vi.mock('../components/RelatedProduct', () => ({
+  default: ({ category, subCategory }) => (
+    <div
+      data-testid='related-product'
+      data-category={category}
+      data-subcategory={subCategory}
+    >
+      RelatedProduct
+    </div>
+  ),
+}))
+
+const mockProduct = {
+  _id: 'p1',
+  name: 'Test Shirt',
+  price: 49,
+  description: 'A great shirt',
+  category: 'Men',
+  subCategory: 'Topwear',
+  image: ['img1.png', 'img2.png', 'img3.png'],
+  sizes: ['S', 'M', 'L', 'XL'],
+}
+
+const mockAddToCart = vi.fn()
+
+const renderProduct = (products = [mockProduct]) =>
+  render(
+    <ShopContext.Provider
+      value={{ products, currency: '$', addToCart: mockAddToCart }}
+    >
+      <Product />
+    </ShopContext.Provider>
+  )
+
+describe('Product Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Rendering — product not found', () => {
+    it('renders empty div when productId not in products list', () => {
+      const { container } = renderProduct([])
+      expect(container.firstChild).toHaveClass('opacity-0')
+      expect(screen.queryByText('ADD TO CART')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Rendering — product found', () => {
+    it('renders product name, price, and description', () => {
+      renderProduct()
+      expect(screen.getByText('Test Shirt')).toBeInTheDocument()
+      expect(screen.getByText('$49')).toBeInTheDocument()
+      expect(screen.getByText('A great shirt')).toBeInTheDocument()
+    })
+
+    it('renders all thumbnail images', () => {
+      const { container } = renderProduct()
+      const thumbnails = Array.from(
+        container.querySelectorAll('img.cursor-pointer')
+      )
+      expect(thumbnails).toHaveLength(3)
+    })
+
+    it('sets first thumbnail as main image on load', () => {
+      const { container } = renderProduct()
+      const mainImg = container.querySelector('img.h-auto')
+      expect(mainImg).toHaveAttribute('src', 'img1.png')
+    })
+
+    it('renders all size buttons', () => {
+      renderProduct()
+      expect(screen.getByRole('button', { name: 'S' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'M' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'L' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'XL' })).toBeInTheDocument()
+    })
+
+    it('renders static policy lines', () => {
+      renderProduct()
+      expect(screen.getByText('100% Original Product.')).toBeInTheDocument()
+      expect(
+        screen.getByText(/Cash o delivery is available/i)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/Easy return and exchange policy/i)
+      ).toBeInTheDocument()
+    })
+
+    it('renders Description and Reviews tabs', () => {
+      renderProduct()
+      expect(screen.getByText('Description')).toBeInTheDocument()
+      expect(screen.getByText('Reviews (122)')).toBeInTheDocument()
+    })
+
+    it('renders RelatedProduct with correct category and subCategory', () => {
+      renderProduct()
+      const related = screen.getByTestId('related-product')
+      expect(related).toHaveAttribute('data-category', 'Men')
+      expect(related).toHaveAttribute('data-subcategory', 'Topwear')
+    })
+  })
+
+  describe('Image interaction', () => {
+    it('clicking a thumbnail updates the main displayed image', () => {
+      const { container } = renderProduct()
+      const img2Thumbnail = Array.from(
+        container.querySelectorAll('img.cursor-pointer')
+      ).find((img) => img.getAttribute('src') === 'img2.png')
+      fireEvent.click(img2Thumbnail)
+      const mainImg = container.querySelector('img.h-auto')
+      expect(mainImg).toHaveAttribute('src', 'img2.png')
+    })
+  })
+
+  describe('Size selection', () => {
+    it('clicking a size button applies selected style', () => {
+      renderProduct()
+      const mButton = screen.getByRole('button', { name: 'M' })
+      fireEvent.click(mButton)
+      expect(mButton).toHaveClass('border-orange-500')
+    })
+
+    it('clicking a different size moves selected style', () => {
+      renderProduct()
+      const mButton = screen.getByRole('button', { name: 'M' })
+      const lButton = screen.getByRole('button', { name: 'L' })
+      fireEvent.click(mButton)
+      fireEvent.click(lButton)
+      expect(lButton).toHaveClass('border-orange-500')
+      expect(mButton).not.toHaveClass('border-orange-500')
+    })
+  })
+
+  describe('Add to cart', () => {
+    it('calls addToCart with product id and selected size', () => {
+      renderProduct()
+      fireEvent.click(screen.getByRole('button', { name: 'M' }))
+      fireEvent.click(screen.getByRole('button', { name: 'ADD TO CART' }))
+      expect(mockAddToCart).toHaveBeenCalledWith('p1', 'M')
+    })
+  })
+})


### PR DESCRIPTION
## Updates
- Unit tests for Product, RelatedProduct, ProductItem components
  + Product page integration tests
- Unit tests for productController (all 5 handlers, cloudinary mock,
  coercion logic)
- Unit tests for productModel 
- Integration tests for all product routes (auth, cloudinary, real DB
  via mongodb-memory-server)
- Added custom `validate` to productModel image and sizes fields —
  mongoose Array type silently accepts `[]` despite `required: true`