### PR TITLE
feat(tests): order tests

### DIFF
--- a/backend/controllers/userOrders.test.js
+++ b/backend/controllers/userOrders.test.js
@@ -1,0 +1,65 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// ─── Mock setup ───────────────────────────────────────────────────────────────
+
+const MockOrderModel = jest.fn()
+MockOrderModel.find = jest.fn()
+
+jest.unstable_mockModule('../models/orderModel.js', () => ({
+  default: MockOrderModel,
+}))
+
+jest.unstable_mockModule('../models/userModel.js', () => ({
+  default: { findByIdAndUpdate: jest.fn() },
+}))
+
+// orderController instantiates `new Stripe(...)` at module load
+jest.unstable_mockModule('stripe', () => ({
+  default: jest.fn(() => ({ checkout: { sessions: { create: jest.fn() } } })),
+}))
+
+// ─── Dynamic imports ──────────────────────────────────────────────────────────
+
+const { userOrders } = await import('./orderController.js')
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeRes = () => ({ json: jest.fn(), status: jest.fn().mockReturnThis() })
+
+// ─── userOrders ─────────────────────────────────────────────────────────────
+
+describe('userOrders', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns orders for the given userId with success: true', async () => {
+    const orders = [{ _id: 'o1', userId: 'u1' }]
+    MockOrderModel.find.mockResolvedValue(orders)
+
+    const res = makeRes()
+    await userOrders({ body: { userId: 'u1' } }, res)
+
+    expect(MockOrderModel.find).toHaveBeenCalledWith({ userId: 'u1' })
+    expect(res.json).toHaveBeenCalledWith({ success: true, orders })
+  })
+
+  it('returns an empty list when the user has no orders', async () => {
+    MockOrderModel.find.mockResolvedValue([])
+
+    const res = makeRes()
+    await userOrders({ body: { userId: 'u1' } }, res)
+
+    expect(res.json).toHaveBeenCalledWith({ success: true, orders: [] })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    MockOrderModel.find.mockRejectedValue(new Error('DB error'))
+
+    const res = makeRes()
+    await userOrders({ body: { userId: 'u1' } }, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'DB error',
+    })
+  })
+})

--- a/backend/controllers/verifyStripe.test.js
+++ b/backend/controllers/verifyStripe.test.js
@@ -1,0 +1,86 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// ─── Mock setup ───────────────────────────────────────────────────────────────
+
+const MockOrderModel = jest.fn()
+MockOrderModel.findByIdAndUpdate = jest.fn()
+MockOrderModel.findByIdAndDelete = jest.fn()
+
+const MockUserModel = { findByIdAndUpdate: jest.fn() }
+
+jest.unstable_mockModule('../models/orderModel.js', () => ({
+  default: MockOrderModel,
+}))
+
+jest.unstable_mockModule('../models/userModel.js', () => ({
+  default: MockUserModel,
+}))
+
+// orderController instantiates `new Stripe(...)` at module load
+jest.unstable_mockModule('stripe', () => ({
+  default: jest.fn(() => ({ checkout: { sessions: { create: jest.fn() } } })),
+}))
+
+// ─── Dynamic imports ──────────────────────────────────────────────────────────
+
+const { verifyStripe } = await import('./orderController.js')
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeRes = () => ({ json: jest.fn(), status: jest.fn().mockReturnThis() })
+
+// ─── verifyStripe ─────────────────────────────────────────────────────────────
+
+describe('verifyStripe', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('marks order paid and clears cart when success === "true"', async () => {
+    MockOrderModel.findByIdAndUpdate.mockResolvedValue()
+    MockUserModel.findByIdAndUpdate.mockResolvedValue()
+
+    const res = makeRes()
+    await verifyStripe(
+      { body: { orderId: 'o1', success: 'true', userId: 'u1' } },
+      res
+    )
+
+    expect(MockOrderModel.findByIdAndUpdate).toHaveBeenCalledWith('o1', {
+      payment: true,
+    })
+    expect(MockUserModel.findByIdAndUpdate).toHaveBeenCalledWith('u1', {
+      cartData: {},
+    })
+    expect(MockOrderModel.findByIdAndDelete).not.toHaveBeenCalled()
+    expect(res.json).toHaveBeenCalledWith({ success: true })
+  })
+
+  it('deletes the order when success is not "true"', async () => {
+    MockOrderModel.findByIdAndDelete.mockResolvedValue()
+
+    const res = makeRes()
+    await verifyStripe(
+      { body: { orderId: 'o1', success: 'false', userId: 'u1' } },
+      res
+    )
+
+    expect(MockOrderModel.findByIdAndDelete).toHaveBeenCalledWith('o1')
+    expect(MockOrderModel.findByIdAndUpdate).not.toHaveBeenCalled()
+    expect(MockUserModel.findByIdAndUpdate).not.toHaveBeenCalled()
+    expect(res.json).toHaveBeenCalledWith({ success: false })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    MockOrderModel.findByIdAndUpdate.mockRejectedValue(new Error('DB error'))
+
+    const res = makeRes()
+    await verifyStripe(
+      { body: { orderId: 'o1', success: 'true', userId: 'u1' } },
+      res
+    )
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'DB error',
+    })
+  })
+})

--- a/backend/routes/userOrders.integration.test.js
+++ b/backend/routes/userOrders.integration.test.js
@@ -1,0 +1,112 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  jest,
+} from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+
+// ─── Env before importing the route (Stripe is constructed at module load) ─────
+
+process.env.JWT_SECRET = 'test-secret'
+process.env.STRIPE_SECRET_KEY = 'sk_test_dummy'
+
+const { default: orderRouter } = await import('./orderRoute.js')
+const { default: orderModel } = await import('../models/orderModel.js')
+
+// ─── Test app ─────────────────────────────────────────────────────────────────
+
+const app = express()
+app.use(express.json())
+app.use('/api/order', orderRouter)
+
+// ─── Database setup ───────────────────────────────────────────────────────────
+
+let mongoServer
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create()
+  await mongoose.connect(mongoServer.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+afterEach(async () => {
+  await orderModel.deleteMany({})
+  jest.clearAllMocks()
+})
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const tokenFor = (id) =>
+  jwt.sign({ id }, process.env.JWT_SECRET, { expiresIn: '1d' })
+
+const seedOrder = (overrides = {}) =>
+  orderModel.create({
+    userId: 'user-1',
+    items: [{ name: 'Shirt', quantity: 1, price: 100, size: 'M' }],
+    amount: 110,
+    address: { firstName: 'Jane' },
+    paymentMethod: 'COD',
+    payment: false,
+    date: Date.now(),
+    ...overrides,
+  })
+
+// ─── POST /api/order/userorders ───────────────────────────────────────────────
+
+describe('POST /api/order/userorders', () => {
+  it("returns only the authenticated user's orders", async () => {
+    await seedOrder({ userId: 'user-1', amount: 110 })
+    await seedOrder({ userId: 'user-1', amount: 220 })
+    await seedOrder({ userId: 'other-user', amount: 999 })
+
+    const res = await request(app)
+      .post('/api/order/userorders')
+      .set('Authorization', `Bearer ${tokenFor('user-1')}`)
+      .send({})
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.orders).toHaveLength(2)
+    expect(res.body.orders.every((o) => o.userId === 'user-1')).toBe(true)
+  })
+
+  it('returns an empty list when the user has no orders', async () => {
+    await seedOrder({ userId: 'someone-else' })
+
+    const res = await request(app)
+      .post('/api/order/userorders')
+      .set('Authorization', `Bearer ${tokenFor('user-1')}`)
+      .send({})
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.orders).toEqual([])
+  })
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).post('/api/order/userorders').send({})
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+
+  it('returns 401 with an invalid token', async () => {
+    const res = await request(app)
+      .post('/api/order/userorders')
+      .set('Authorization', 'Bearer not-a-real-token')
+      .send({})
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+})

--- a/backend/routes/verifyStripe.integration.test.js
+++ b/backend/routes/verifyStripe.integration.test.js
@@ -1,0 +1,121 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  jest,
+} from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+
+// ─── Env before importing the route (Stripe is constructed at module load) ─────
+
+process.env.JWT_SECRET = 'test-secret'
+process.env.STRIPE_SECRET_KEY = 'sk_test_dummy'
+
+const { default: orderRouter } = await import('./orderRoute.js')
+const { default: orderModel } = await import('../models/orderModel.js')
+const { default: userModel } = await import('../models/userModel.js')
+
+// ─── Test app ─────────────────────────────────────────────────────────────────
+
+const app = express()
+app.use(express.json())
+app.use('/api/order', orderRouter)
+
+// ─── Database setup ───────────────────────────────────────────────────────────
+
+let mongoServer
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create()
+  await mongoose.connect(mongoServer.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+afterEach(async () => {
+  await orderModel.deleteMany({})
+  await userModel.deleteMany({})
+  jest.clearAllMocks()
+})
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const tokenFor = (id) =>
+  jwt.sign({ id }, process.env.JWT_SECRET, { expiresIn: '1d' })
+
+const seedUser = () =>
+  userModel.create({
+    name: 'Jane',
+    email: 'jane@example.com',
+    password: 'hashed',
+    cartData: { p1: { M: 2 } },
+  })
+
+const seedOrder = (userId) =>
+  orderModel.create({
+    userId,
+    items: [{ name: 'Shirt', quantity: 1, price: 100, size: 'M' }],
+    amount: 110,
+    address: { firstName: 'Jane' },
+    paymentMethod: 'Stripe',
+    payment: false,
+    date: Date.now(),
+  })
+
+// ─── POST /api/order/verifystripe ─────────────────────────────────────────────
+
+describe('POST /api/order/verifystripe', () => {
+  it('marks the order paid and clears the cart on success=true', async () => {
+    const user = await seedUser()
+    const order = await seedOrder(user._id.toString())
+
+    const res = await request(app)
+      .post('/api/order/verifystripe')
+      .set('Authorization', `Bearer ${tokenFor(user._id.toString())}`)
+      .send({ orderId: order._id.toString(), success: 'true' })
+
+    expect(res.body.success).toBe(true)
+
+    const updatedOrder = await orderModel.findById(order._id)
+    expect(updatedOrder.payment).toBe(true)
+
+    const updatedUser = await userModel.findById(user._id)
+    expect(updatedUser.cartData).toEqual({})
+  })
+
+  it('deletes the order and leaves the cart on success=false', async () => {
+    const user = await seedUser()
+    const order = await seedOrder(user._id.toString())
+
+    const res = await request(app)
+      .post('/api/order/verifystripe')
+      .set('Authorization', `Bearer ${tokenFor(user._id.toString())}`)
+      .send({ orderId: order._id.toString(), success: 'false' })
+
+    expect(res.body.success).toBe(false)
+
+    expect(await orderModel.findById(order._id)).toBeNull()
+
+    const untouchedUser = await userModel.findById(user._id)
+    expect(untouchedUser.cartData).toEqual({ p1: { M: 2 } })
+  })
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app)
+      .post('/api/order/verifystripe')
+      .send({ orderId: 'x', success: 'true' })
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+})

--- a/frontend/src/pages/Orders.integration.test.jsx
+++ b/frontend/src/pages/Orders.integration.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import Orders from './Orders'
+import ShopContextProvider from '../context/ShopContext'
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const order = {
+  status: 'Order Placed',
+  payment: false,
+  paymentMethod: 'COD',
+  date: 1700000000000,
+  items: [
+    {
+      name: 'Integration Shirt',
+      price: 100,
+      quantity: 2,
+      size: 'L',
+      image: ['s.png'],
+    },
+  ],
+}
+
+const renderOrders = () =>
+  render(
+    <MemoryRouter initialEntries={['/orders']}>
+      <ShopContextProvider>
+        <Routes>
+          <Route path='/orders' element={<Orders />} />
+        </Routes>
+      </ShopContextProvider>
+    </MemoryRouter>
+  )
+
+describe('Orders Page Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    // provider on-mount calls: product list (get) + cart get (post)
+    axios.get.mockResolvedValue({ data: { success: true, products: [] } })
+    axios.post.mockImplementation((url) => {
+      if (url.endsWith('/api/cart/get')) {
+        return Promise.resolve({ data: { success: true, cartData: {} } })
+      }
+      if (url.endsWith('/api/order/userorders')) {
+        return Promise.resolve({ data: { success: true, orders: [order] } })
+      }
+      return Promise.resolve({ data: { success: true } })
+    })
+  })
+
+  afterEach(() => localStorage.clear())
+
+  it('loads the token from storage and renders the user orders via real ShopContext', async () => {
+    localStorage.setItem('token', 'stored-token')
+
+    renderOrders()
+
+    // order row rendered from the real provider → Orders wiring
+    expect(await screen.findByText('Integration Shirt')).toBeInTheDocument()
+    expect(screen.getByText('$100')).toBeInTheDocument()
+    expect(screen.getByText('Quantity: 2')).toBeInTheDocument()
+
+    // userorders was called with the token pulled from localStorage
+    await waitFor(() => {
+      const call = axios.post.mock.calls.find(([u]) =>
+        u.endsWith('/api/order/userorders')
+      )
+      expect(call).toBeTruthy()
+      expect(call[2]).toEqual({
+        headers: { Authorization: 'Bearer stored-token' },
+      })
+    })
+  })
+
+  it('renders no order rows when there is no token', async () => {
+    renderOrders()
+
+    await waitFor(() => {
+      expect(
+        axios.post.mock.calls.some(([u]) => u.endsWith('/api/order/userorders'))
+      ).toBe(false)
+    })
+    expect(screen.queryByText('Integration Shirt')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Orders.test.jsx
+++ b/frontend/src/pages/Orders.test.jsx
@@ -142,4 +142,15 @@ describe('Orders Page', () => {
       expect(toast.error).toHaveBeenCalledWith('Network Error')
     )
   })
+
+  it('renders no order rows when the API responds success: false', async () => {
+    axios.post.mockResolvedValue({ data: { success: false } })
+    const { container } = renderOrders()
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled())
+    expect(
+      screen.queryByRole('button', { name: 'Track Order' })
+    ).not.toBeInTheDocument()
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/Orders.test.jsx
+++ b/frontend/src/pages/Orders.test.jsx
@@ -1,0 +1,145 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import Orders from './Orders'
+import { ShopContext } from '../context/ShopContext'
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn() },
+}))
+
+// Title renders MY ORDERS heading; stub to keep this a unit test
+vi.mock('../components/Title', () => ({
+  default: ({ text1, text2 }) => (
+    <div data-testid='title'>
+      {text1} {text2}
+    </div>
+  ),
+}))
+
+const makeItem = (overrides = {}) => ({
+  name: 'Shirt',
+  price: 100,
+  quantity: 1,
+  size: 'M',
+  image: ['img1.png'],
+  ...overrides,
+})
+
+const makeOrder = (overrides = {}) => ({
+  status: 'Order Placed',
+  payment: false,
+  paymentMethod: 'COD',
+  date: 1700000000000,
+  items: [makeItem()],
+  ...overrides,
+})
+
+const renderOrders = (contextValue) =>
+  render(
+    <ShopContext.Provider
+      value={{
+        backendUrl: 'http://localhost:1001',
+        currency: '$',
+        token: 'tkn',
+        ...contextValue,
+      }}
+    >
+      <Orders />
+    </ShopContext.Provider>
+  )
+
+describe('Orders Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    axios.post.mockResolvedValue({ data: { success: true, orders: [] } })
+  })
+
+  it('does not fetch orders when no token is set', async () => {
+    renderOrders({ token: '' })
+    await waitFor(() => {})
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('posts to userorders with the auth header when a token is set', async () => {
+    renderOrders()
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/order/userorders',
+        {},
+        { headers: { Authorization: 'Bearer tkn' } }
+      )
+    })
+  })
+
+  it('renders an order row with product details from the response', async () => {
+    axios.post.mockResolvedValue({
+      data: { success: true, orders: [makeOrder()] },
+    })
+    renderOrders()
+
+    expect(await screen.findByText('Shirt')).toBeInTheDocument()
+    expect(screen.getByText('$100')).toBeInTheDocument()
+    expect(screen.getByText('Quantity: 1')).toBeInTheDocument()
+    expect(screen.getByText('Size: M')).toBeInTheDocument()
+    expect(screen.getByText('Order Placed')).toBeInTheDocument()
+  })
+
+  it('flattens items across multiple orders into individual rows', async () => {
+    axios.post.mockResolvedValue({
+      data: {
+        success: true,
+        orders: [
+          makeOrder({
+            items: [makeItem({ name: 'A' }), makeItem({ name: 'B' })],
+          }),
+          makeOrder({ items: [makeItem({ name: 'C' })] }),
+        ],
+      },
+    })
+    renderOrders()
+
+    expect(await screen.findByText('A')).toBeInTheDocument()
+    expect(screen.getByText('B')).toBeInTheDocument()
+    expect(screen.getByText('C')).toBeInTheDocument()
+  })
+
+  it('renders at most the first 4 items', async () => {
+    const items = Array.from({ length: 6 }, (_, i) =>
+      makeItem({ name: `Item ${i}` })
+    )
+    axios.post.mockResolvedValue({
+      data: { success: true, orders: [makeOrder({ items })] },
+    })
+    renderOrders()
+
+    // reversed then sliced(0,4): last 4 pushed items survive
+    expect(await screen.findByText('Item 5')).toBeInTheDocument()
+    expect(screen.queryByText('Item 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Item 0')).not.toBeInTheDocument()
+  })
+
+  it('refetches when Track Order is clicked', async () => {
+    axios.post.mockResolvedValue({
+      data: { success: true, orders: [makeOrder()] },
+    })
+    renderOrders()
+
+    await screen.findByText('Shirt')
+    expect(axios.post).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Track Order' }))
+    await waitFor(() => expect(axios.post).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows an error toast when the request fails', async () => {
+    axios.post.mockRejectedValue(new Error('Network Error'))
+    const { toast } = await import('react-toastify')
+    renderOrders()
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
+    )
+  })
+})

--- a/frontend/src/pages/Verify.integration.test.jsx
+++ b/frontend/src/pages/Verify.integration.test.jsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import Verify from './Verify'
+import ShopContextProvider from '../context/ShopContext'
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const LocationProbe = () => {
+  const loc = useLocation()
+  return <div data-testid='location'>{loc.pathname}</div>
+}
+
+const OrdersStub = () => <div data-testid='orders-page'>Orders</div>
+const CartStub = () => <div data-testid='cart-page'>Cart</div>
+
+const renderVerify = (query) =>
+  render(
+    <MemoryRouter initialEntries={[`/verify${query}`]}>
+      <ShopContextProvider>
+        <Routes>
+          <Route path='/verify' element={<Verify />} />
+          <Route path='/orders' element={<OrdersStub />} />
+          <Route path='/cart' element={<CartStub />} />
+        </Routes>
+        <LocationProbe />
+      </ShopContextProvider>
+    </MemoryRouter>
+  )
+
+describe('Verify Page Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    axios.get.mockResolvedValue({ data: { success: true, products: [] } })
+    axios.post.mockImplementation((url) => {
+      if (url.endsWith('/api/cart/get')) {
+        return Promise.resolve({ data: { success: true, cartData: {} } })
+      }
+      return Promise.resolve({ data: { success: true } })
+    })
+  })
+
+  afterEach(() => localStorage.clear())
+
+  it('verifies payment and navigates to /orders on success via real ShopContext', async () => {
+    localStorage.setItem('token', 'stored-token')
+
+    renderVerify('?success=true&orderId=order-1')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/orders')
+    })
+
+    const call = axios.post.mock.calls.find(([u]) =>
+      u.endsWith('/api/order/verifystripe')
+    )
+    expect(call[1]).toEqual({ success: 'true', orderId: 'order-1' })
+    expect(call[2]).toEqual({
+      headers: { Authorization: 'Bearer stored-token' },
+    })
+  })
+
+  it('navigates to /cart when verification fails', async () => {
+    localStorage.setItem('token', 'stored-token')
+    axios.post.mockImplementation((url) => {
+      if (url.endsWith('/api/cart/get')) {
+        return Promise.resolve({ data: { success: true, cartData: {} } })
+      }
+      return Promise.resolve({ data: { success: false } })
+    })
+
+    renderVerify('?success=false&orderId=order-1')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/cart')
+    })
+  })
+})

--- a/frontend/src/pages/Verify.test.jsx
+++ b/frontend/src/pages/Verify.test.jsx
@@ -1,0 +1,87 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import Verify from './Verify'
+import { ShopContext } from '../context/ShopContext'
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn() },
+}))
+
+// Control the query string Verify reads
+let mockParams = new URLSearchParams('success=true&orderId=order-1')
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [mockParams],
+}))
+
+const renderVerify = (contextValue) =>
+  render(
+    <ShopContext.Provider
+      value={{
+        backendUrl: 'http://localhost:1001',
+        token: 'tkn',
+        navigate: vi.fn(),
+        setCartItems: vi.fn(),
+        ...contextValue,
+      }}
+    >
+      <Verify />
+    </ShopContext.Provider>
+  )
+
+describe('Verify Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockParams = new URLSearchParams('success=true&orderId=order-1')
+    axios.post.mockResolvedValue({ data: { success: true } })
+  })
+
+  it('does not call the API when no token is set', async () => {
+    renderVerify({ token: '' })
+    await waitFor(() => {})
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('posts success and orderId with the auth header', async () => {
+    renderVerify()
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/order/verifystripe',
+        { success: 'true', orderId: 'order-1' },
+        { headers: { Authorization: 'Bearer tkn' } }
+      )
+    })
+  })
+
+  it('clears the cart and navigates to /orders on success', async () => {
+    const navigate = vi.fn()
+    const setCartItems = vi.fn()
+    renderVerify({ navigate, setCartItems })
+
+    await waitFor(() => {
+      expect(setCartItems).toHaveBeenCalledWith({})
+      expect(navigate).toHaveBeenCalledWith('/orders')
+    })
+  })
+
+  it('navigates to /cart when verification is unsuccessful', async () => {
+    axios.post.mockResolvedValue({ data: { success: false } })
+    const navigate = vi.fn()
+    const setCartItems = vi.fn()
+    renderVerify({ navigate, setCartItems })
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/cart'))
+    expect(setCartItems).not.toHaveBeenCalled()
+  })
+
+  it('shows an error toast when the request fails', async () => {
+    axios.post.mockRejectedValue(new Error('Network Error'))
+    const { toast } = await import('react-toastify')
+    renderVerify()
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
+    )
+  })
+})


### PR DESCRIPTION
## Problem
The **Orders** (order history) and **Verify** (Stripe payment confirmation) flows had **no test coverage** — order fetching/flattening, the payment-verification branch, cart-clearing side effects, and the auth-guarded endpoints were all unverified.

## Solution
Unit + integration tests for the **Orders** and **Verify** features across frontend and backend. 8 new files, 30 tests.

These cover the two remaining user-facing `orderController` handlers not addressed in the Cart/PlaceOrder PR (`userOrders`, `verifyStripe`) plus their frontend pages.

### Backend
| File | Type | Tests |
|------|------|-------|
| `backend/controllers/userOrders.test.js` | unit | 3 — returns the user's orders, empty list, error path (models mocked) |
| `backend/controllers/verifyStripe.test.js` | unit | 3 — success→mark paid + clear cart, fail→delete order, error path (both branches) |
| `backend/routes/userOrders.integration.test.js` | integration | 4 — real Mongo: only the authed user's orders, empty list, 401 no token, 401 bad token |
| `backend/routes/verifyStripe.integration.test.js` | integration | 3 — success marks order paid + clears cart in DB, fail deletes order + leaves cart, 401 |

### Frontend
| File | Type | Tests |
|------|------|-------|
| `frontend/src/pages/Orders.test.jsx` | unit | 9 — token gate, auth header, row render, flatten items across orders, 4-item slice, Track Order refetch, error toast, `success:false` → no rows |
| `frontend/src/pages/Verify.test.jsx` | unit | 5 — token gate, payload+header, success→clear cart+`/orders`, fail→`/cart`, error toast |
| `frontend/src/pages/Orders.integration.test.jsx` | integration | 2 — real ShopContext loads token from storage → renders orders; no token → no fetch |
| `frontend/src/pages/Verify.integration.test.jsx` | integration | 2 — real provider+router: success→navigates `/orders`, fail→navigates `/cart` |


🤖 Generated with [Claude Code](https://claude.com/claude-code)
