### PR TITLE
feat(tests): admin tests

### DIFF
--- a/.github/workflows/admin-tests.yml
+++ b/.github/workflows/admin-tests.yml
@@ -1,0 +1,50 @@
+name: Admin Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'admin/**'
+      - '.github/workflows/admin-tests.yml'
+  pull_request:
+    paths:
+      - 'admin/**'
+      - '.github/workflows/admin-tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run Admin Unit & Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ./admin/package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+        working-directory: ./admin
+
+      - name: Run Tests & Coverage
+        run: npm run test:coverage
+        working-directory: ./admin
+
+      - name: Post Coverage Comment
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LCOV_FILE: ./admin/coverage/lcov.info
+          REPORT_TITLE: Admin Coverage Report
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node .github/scripts/post-coverage-comment.js

--- a/admin/src/App.integration.test.jsx
+++ b/admin/src/App.integration.test.jsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import { MemoryRouter } from 'react-router-dom'
+import App from './App'
+
+// Only the network is faked — Navbar, SideBar, Login and the pages are REAL,
+// so this exercises how the dashboard shell wires together.
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    interceptors: { response: { use: vi.fn(() => 1), eject: vi.fn() } },
+  },
+}))
+
+vi.mock('react-toastify', () => ({
+  ToastContainer: () => null,
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const products = [
+  {
+    _id: 'p1',
+    name: 'Blue Shirt',
+    category: 'Men',
+    price: 49,
+    image: ['b.png'],
+  },
+]
+
+const renderAppAt = (path) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>
+  )
+
+describe('Admin App Integration (dashboard shell)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    axios.get.mockResolvedValue({ data: { success: true, products } })
+    axios.post.mockResolvedValue({ data: { success: true, orders: [] } })
+  })
+
+  afterEach(() => localStorage.clear())
+
+  it('renders Navbar and SideBar together when logged in', () => {
+    localStorage.setItem('token', 'tkn')
+    renderAppAt('/add')
+
+    // real Navbar
+    expect(screen.getByRole('button', { name: 'Logout' })).toBeInTheDocument()
+    // real SideBar links
+    expect(screen.getByText('Add Items')).toBeInTheDocument()
+    expect(screen.getByText('List Items')).toBeInTheDocument()
+    expect(screen.getByText('Orders')).toBeInTheDocument()
+    // real Add page mounted at /add
+    expect(screen.getByText('Upload Image')).toBeInTheDocument()
+  })
+
+  it('navigates via the SideBar links and mounts the matching page', async () => {
+    localStorage.setItem('token', 'tkn')
+    renderAppAt('/add')
+
+    // click the SideBar "List Items" link → route changes → List page renders
+    fireEvent.click(screen.getByText('List Items'))
+
+    expect(await screen.findByText('All Products Lists')).toBeInTheDocument()
+    expect(await screen.findByText('Blue Shirt')).toBeInTheDocument()
+  })
+
+  it('logs out through the real Navbar and returns to the Login screen', async () => {
+    localStorage.setItem('token', 'tkn')
+    renderAppAt('/add')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Logout' }))
+
+    // real Login component appears; dashboard shell gone
+    expect(
+      await screen.findByRole('heading', { name: /Admin Panel/i })
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Add Items')).not.toBeInTheDocument()
+  })
+
+  it('shows the Login screen (no shell) when there is no token', () => {
+    renderAppAt('/add')
+
+    expect(
+      screen.getByRole('heading', { name: /Admin Panel/i })
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Add Items')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Logout' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/admin/src/App.test.jsx
+++ b/admin/src/App.test.jsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import { MemoryRouter } from 'react-router-dom'
+import App from './App'
+
+// axios is used only for its interceptor wiring in App
+vi.mock('axios', () => ({
+  default: {
+    interceptors: {
+      response: { use: vi.fn(() => 1), eject: vi.fn() },
+    },
+  },
+}))
+
+vi.mock('react-toastify', () => ({
+  ToastContainer: () => null,
+  toast: { error: vi.fn() },
+}))
+
+// Stub children so the test targets App's own auth-gate / token logic.
+vi.mock('./components/Login', () => ({
+  default: ({ setToken }) => (
+    <button onClick={() => setToken('new-token')}>do-login</button>
+  ),
+}))
+vi.mock('./components/Navbar', () => ({
+  default: ({ setToken }) => (
+    <button onClick={() => setToken('')}>do-logout</button>
+  ),
+}))
+vi.mock('./components/SideBar', () => ({
+  default: () => <div data-testid='sidebar'>SideBar</div>,
+}))
+vi.mock('./pages/Add', () => ({ default: () => <div>Add</div> }))
+vi.mock('./pages/List', () => ({ default: () => <div>List</div> }))
+vi.mock('./pages/Order', () => ({ default: () => <div>Order</div> }))
+
+const renderApp = () =>
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  )
+
+describe('Admin App', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  afterEach(() => localStorage.clear())
+
+  it('shows the Login screen when there is no token', () => {
+    renderApp()
+
+    expect(screen.getByText('do-login')).toBeInTheDocument()
+    expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument()
+  })
+
+  it('shows the dashboard (Navbar + SideBar) when a token exists', () => {
+    localStorage.setItem('token', 'existing-token')
+    renderApp()
+
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+    expect(screen.getByText('do-logout')).toBeInTheDocument()
+    expect(screen.queryByText('do-login')).not.toBeInTheDocument()
+  })
+
+  it('logs in, revealing the dashboard and persisting the token', async () => {
+    renderApp()
+
+    fireEvent.click(screen.getByText('do-login'))
+
+    expect(await screen.findByTestId('sidebar')).toBeInTheDocument()
+    expect(localStorage.getItem('token')).toBe('new-token')
+  })
+
+  it('logs out, returning to Login and clearing the stored token', async () => {
+    localStorage.setItem('token', 'existing-token')
+    renderApp()
+
+    fireEvent.click(screen.getByText('do-logout'))
+
+    expect(await screen.findByText('do-login')).toBeInTheDocument()
+    expect(localStorage.getItem('token')).toBe('')
+  })
+
+  it('clears the token and toasts on a 401 response via the interceptor', async () => {
+    localStorage.setItem('token', 'existing-token')
+    renderApp()
+
+    // App registered a response interceptor; grab its error handler
+    const errorHandler = axios.interceptors.response.use.mock.calls[0][1]
+    const { toast } = await import('react-toastify')
+
+    await expect(
+      errorHandler({ response: { status: 401 } })
+    ).rejects.toBeDefined()
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Session expired. Please log in again.'
+    )
+    // token cleared → Login screen returns
+    expect(await screen.findByText('do-login')).toBeInTheDocument()
+  })
+})

--- a/admin/src/App.test.jsx
+++ b/admin/src/App.test.jsx
@@ -104,4 +104,28 @@ describe('Admin App', () => {
     // token cleared → Login screen returns
     expect(await screen.findByText('do-login')).toBeInTheDocument()
   })
+
+  it('passes a successful response through the interceptor unchanged', () => {
+    renderApp()
+
+    const successHandler = axios.interceptors.response.use.mock.calls[0][0]
+    const response = { data: 'ok' }
+    expect(successHandler(response)).toBe(response)
+  })
+
+  it('re-rejects a non-401 error without logging out or toasting', async () => {
+    localStorage.setItem('token', 'existing-token')
+    renderApp()
+
+    const errorHandler = axios.interceptors.response.use.mock.calls[0][1]
+    const { toast } = await import('react-toastify')
+    const error = { response: { status: 500 } }
+
+    await expect(errorHandler(error)).rejects.toBe(error)
+
+    expect(toast.error).not.toHaveBeenCalled()
+    // still on the dashboard, not kicked back to Login
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+    expect(screen.queryByText('do-login')).not.toBeInTheDocument()
+  })
 })

--- a/admin/src/components/Navbar.test.jsx
+++ b/admin/src/components/Navbar.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Navbar from './Navbar'
+
+describe('Admin Navbar', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the logo and a Logout button', () => {
+    const { container } = render(<Navbar setToken={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Logout' })).toBeInTheDocument()
+    expect(container.querySelector('img')).toBeInTheDocument()
+  })
+
+  it('clears the token when Logout is clicked', () => {
+    const setToken = vi.fn()
+    render(<Navbar setToken={setToken} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Logout' }))
+    expect(setToken).toHaveBeenCalledWith('')
+  })
+})

--- a/admin/src/components/SideBar.test.jsx
+++ b/admin/src/components/SideBar.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import SideBar from './SideBar'
+
+const renderSideBar = () =>
+  render(
+    <MemoryRouter>
+      <SideBar />
+    </MemoryRouter>
+  )
+
+describe('Admin SideBar', () => {
+  it('renders the three navigation labels', () => {
+    renderSideBar()
+
+    expect(screen.getByText('Add Items')).toBeInTheDocument()
+    expect(screen.getByText('List Items')).toBeInTheDocument()
+    expect(screen.getByText('Orders')).toBeInTheDocument()
+  })
+
+  it('links each item to its route', () => {
+    renderSideBar()
+
+    expect(screen.getByText('Add Items').closest('a')).toHaveAttribute(
+      'href',
+      '/add'
+    )
+    expect(screen.getByText('List Items').closest('a')).toHaveAttribute(
+      'href',
+      '/list'
+    )
+    expect(screen.getByText('Orders').closest('a')).toHaveAttribute(
+      'href',
+      '/order'
+    )
+  })
+})

--- a/admin/src/pages/Add.integration.test.jsx
+++ b/admin/src/pages/Add.integration.test.jsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import axios from 'axios'
+import Add from './Add'
+
+vi.mock('../App', () => ({
+  backendUrl: 'http://localhost:1001',
+}))
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const fillRequired = () => {
+  fireEvent.change(screen.getByPlaceholderText('Type here'), {
+    target: { value: 'Cool Shirt' },
+  })
+  fireEvent.change(screen.getByPlaceholderText('Write content here'), {
+    target: { value: 'A very cool shirt' },
+  })
+  fireEvent.change(screen.getByPlaceholderText('25'), {
+    target: { value: '49' },
+  })
+}
+
+const submit = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+describe('Admin Add Page Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // jsdom has no URL.createObjectURL (used for image preview)
+    URL.createObjectURL = vi.fn(() => 'blob:preview')
+    axios.post.mockResolvedValue({
+      data: { success: true, message: 'Product Added' },
+    })
+  })
+
+  afterEach(() => {
+    delete URL.createObjectURL
+  })
+
+  it('posts the product as FormData with the auth header', async () => {
+    render(<Add token='tkn' />)
+    fillRequired()
+    fireEvent.click(screen.getByText('S'))
+    fireEvent.click(screen.getByText('M'))
+    submit()
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled())
+
+    const [url, formData, config] = axios.post.mock.calls[0]
+    expect(url).toBe('http://localhost:1001/api/product/add')
+    expect(config).toEqual({ headers: { Authorization: 'Bearer tkn' } })
+    expect(formData.get('name')).toBe('Cool Shirt')
+    expect(formData.get('description')).toBe('A very cool shirt')
+    expect(formData.get('price')).toBe('49')
+    expect(formData.get('category')).toBe('Men')
+    expect(formData.get('sizes')).toBe(JSON.stringify(['S', 'M']))
+  })
+
+  it('appends selected category/subCategory and uploaded image', async () => {
+    render(<Add token='tkn' />)
+    fillRequired()
+
+    fireEvent.change(screen.getAllByRole('combobox')[0], {
+      target: { value: 'Women' },
+    })
+    fireEvent.change(screen.getAllByRole('combobox')[1], {
+      target: { value: 'Winterwear' },
+    })
+    const file = new File(['img'], 'photo.png', { type: 'image/png' })
+    fireEvent.change(document.getElementById('image1'), {
+      target: { files: [file] },
+    })
+
+    submit()
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled())
+    const formData = axios.post.mock.calls[0][1]
+    expect(formData.get('category')).toBe('Women')
+    expect(formData.get('subCategory')).toBe('Winterwear')
+    expect(formData.get('image1')).toBeInstanceOf(File)
+  })
+
+  it('shows a success toast and clears fields on success', async () => {
+    const { toast } = await import('react-toastify')
+    render(<Add token='tkn' />)
+    fillRequired()
+    submit()
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith('Product Added')
+    )
+    expect(screen.getByPlaceholderText('Type here')).toHaveValue('')
+    expect(screen.getByPlaceholderText('25')).toHaveValue(null)
+  })
+
+  it('shows an error toast when the API returns success: false', async () => {
+    axios.post.mockResolvedValue({
+      data: { success: false, message: 'Missing fields' },
+    })
+    const { toast } = await import('react-toastify')
+    render(<Add token='tkn' />)
+    fillRequired()
+    submit()
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Missing fields')
+    )
+  })
+
+  it('shows an error toast when the request rejects', async () => {
+    axios.post.mockRejectedValue(new Error('Network Error'))
+    const { toast } = await import('react-toastify')
+    render(<Add token='tkn' />)
+    fillRequired()
+    submit()
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
+    )
+  })
+})

--- a/admin/src/pages/Add.test.jsx
+++ b/admin/src/pages/Add.test.jsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Add from './Add'
+
+vi.mock('../App', () => ({
+  backendUrl: 'http://localhost:1001',
+}))
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+describe('Admin Add Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the form fields and Add button', () => {
+    render(<Add token='tkn' />)
+
+    expect(screen.getByText('Upload Image')).toBeInTheDocument()
+    expect(screen.getByText('Product name')).toBeInTheDocument()
+    expect(screen.getByText('Product description')).toBeInTheDocument()
+    expect(screen.getByText('Product category')).toBeInTheDocument()
+    expect(screen.getByText('Sub category')).toBeInTheDocument()
+    expect(screen.getByText('Product Price')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument()
+  })
+
+  it('renders all size options', () => {
+    render(<Add token='tkn' />)
+    ;['S', 'M', 'L', 'XL', 'XXL'].forEach((s) => {
+      expect(screen.getByText(s)).toBeInTheDocument()
+    })
+  })
+
+  it('updates the product name as the user types', () => {
+    render(<Add token='tkn' />)
+    const nameInput = screen.getByPlaceholderText('Type here')
+    fireEvent.change(nameInput, { target: { value: 'Cool Shirt' } })
+    expect(nameInput).toHaveValue('Cool Shirt')
+  })
+
+  it('updates the price as the user types', () => {
+    render(<Add token='tkn' />)
+    const priceInput = screen.getByPlaceholderText('25')
+    fireEvent.change(priceInput, { target: { value: '49' } })
+    expect(priceInput).toHaveValue(49)
+  })
+
+  it('toggles a size on and off when clicked', () => {
+    render(<Add token='tkn' />)
+    const sizeM = screen.getByText('M')
+
+    expect(sizeM).toHaveClass('bg-slate-200')
+    fireEvent.click(sizeM)
+    expect(sizeM).toHaveClass('bg-pink-100')
+    fireEvent.click(sizeM)
+    expect(sizeM).toHaveClass('bg-slate-200')
+  })
+
+  it('toggles the bestseller checkbox', () => {
+    render(<Add token='tkn' />)
+    const checkbox = screen.getByRole('checkbox')
+
+    expect(checkbox).not.toBeChecked()
+    fireEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+  })
+})

--- a/admin/src/pages/List.integration.test.jsx
+++ b/admin/src/pages/List.integration.test.jsx
@@ -1,0 +1,120 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import List from './List'
+
+vi.mock('../App', () => ({
+  backendUrl: 'http://localhost:1001',
+  currency: '$',
+}))
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const products = [
+  {
+    _id: 'p1',
+    name: 'Blue Shirt',
+    category: 'Men',
+    price: 49,
+    image: ['b.png'],
+  },
+]
+
+describe('Admin List Page Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    axios.get.mockResolvedValue({ data: { success: true, products } })
+    axios.post.mockResolvedValue({
+      data: { success: true, message: 'Product Removed' },
+    })
+  })
+
+  it('fetches the product list from the API on mount', async () => {
+    render(<List token='tkn' />)
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        'http://localhost:1001/api/product/list'
+      )
+    })
+    expect(await screen.findByText('Blue Shirt')).toBeInTheDocument()
+  })
+
+  it('shows an error toast when the fetch is unsuccessful', async () => {
+    axios.get.mockResolvedValue({
+      data: { success: false, message: 'Server error' },
+    })
+    const { toast } = await import('react-toastify')
+    render(<List token='tkn' />)
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Server error')
+    )
+  })
+
+  it('removes a product with the auth header and refetches on success', async () => {
+    const { toast } = await import('react-toastify')
+    render(<List token='tkn' />)
+    await screen.findByText('Blue Shirt')
+
+    // second fetch (after removal) returns an empty list
+    axios.get.mockResolvedValue({ data: { success: true, products: [] } })
+
+    fireEvent.click(screen.getByText('X'))
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        'http://localhost:1001/api/product/remove',
+        { id: 'p1' },
+        { headers: { Authorization: 'Bearer tkn' } }
+      )
+    })
+    expect(toast.success).toHaveBeenCalledWith('Product Removed')
+
+    // refetch cleared the row
+    await waitFor(() =>
+      expect(screen.queryByText('Blue Shirt')).not.toBeInTheDocument()
+    )
+  })
+
+  it('shows an error toast when the fetch request rejects', async () => {
+    axios.get.mockRejectedValue(new Error('Network Error'))
+    const { toast } = await import('react-toastify')
+    render(<List token='tkn' />)
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
+    )
+  })
+
+  it('shows an error toast when the remove request rejects', async () => {
+    axios.post.mockRejectedValue(new Error('Network Error'))
+    const { toast } = await import('react-toastify')
+    render(<List token='tkn' />)
+    await screen.findByText('Blue Shirt')
+
+    fireEvent.click(screen.getByText('X'))
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
+    )
+  })
+
+  it('shows an error toast and does not refetch when removal fails', async () => {
+    axios.post.mockResolvedValue({
+      data: { success: false, message: 'Not allowed' },
+    })
+    const { toast } = await import('react-toastify')
+    render(<List token='tkn' />)
+    await screen.findByText('Blue Shirt')
+
+    axios.get.mockClear()
+    fireEvent.click(screen.getByText('X'))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Not allowed'))
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+})

--- a/admin/src/pages/List.test.jsx
+++ b/admin/src/pages/List.test.jsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import List from './List'
+
+// Deterministic backendUrl/currency without loading the real App tree.
+vi.mock('../App', () => ({
+  backendUrl: 'http://localhost:1001',
+  currency: '$',
+}))
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const products = [
+  {
+    _id: 'p1',
+    name: 'Blue Shirt',
+    category: 'Men',
+    price: 49,
+    image: ['blue.png'],
+  },
+  {
+    _id: 'p2',
+    name: 'Red Dress',
+    category: 'Women',
+    price: 79,
+    image: ['red.png'],
+  },
+]
+
+describe('Admin List Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    axios.get.mockResolvedValue({ data: { success: true, products } })
+  })
+
+  it('renders the table header labels', async () => {
+    render(<List token='tkn' />)
+    await screen.findByText('Blue Shirt')
+
+    expect(screen.getByText('All Products Lists')).toBeInTheDocument()
+    expect(screen.getByText('Image')).toBeInTheDocument()
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Category')).toBeInTheDocument()
+    expect(screen.getByText('Price')).toBeInTheDocument()
+    expect(screen.getByText('Action')).toBeInTheDocument()
+  })
+
+  it('renders a row per fetched product with name, category and price', async () => {
+    render(<List token='tkn' />)
+
+    expect(await screen.findByText('Blue Shirt')).toBeInTheDocument()
+    expect(screen.getByText('Red Dress')).toBeInTheDocument()
+    expect(screen.getByText('Men')).toBeInTheDocument()
+    expect(screen.getByText('Women')).toBeInTheDocument()
+    expect(screen.getByText('$49')).toBeInTheDocument()
+    expect(screen.getByText('$79')).toBeInTheDocument()
+  })
+
+  it('renders product images from image[0]', async () => {
+    const { container } = render(<List token='tkn' />)
+    await screen.findByText('Blue Shirt')
+
+    const imgs = container.querySelectorAll('img')
+    expect(imgs).toHaveLength(2)
+    expect(imgs[0]).toHaveAttribute('src', 'blue.png')
+  })
+
+  it('renders an empty list (headers only) when there are no products', async () => {
+    axios.get.mockResolvedValue({ data: { success: true, products: [] } })
+    const { container } = render(<List token='tkn' />)
+    await screen.findByText('All Products Lists')
+
+    expect(container.querySelectorAll('img')).toHaveLength(0)
+  })
+})

--- a/admin/src/pages/Order.integration.test.jsx
+++ b/admin/src/pages/Order.integration.test.jsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import Order from './Order'
+
+vi.mock('../App', () => ({
+  backendUrl: 'http://localhost:1001',
+  currency: '$',
+}))
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const baseOrder = {
+  _id: 'o1',
+  items: [{ name: 'Shirt', quantity: 1, size: 'M' }],
+  amount: 110,
+  address: {
+    firstName: 'Jane',
+    lastName: 'Doe',
+    street: '1 Main St',
+    city: 'Town',
+    state: 'ST',
+    country: 'US',
+    zipcode: '12345',
+    phone: '555',
+  },
+  status: 'Order Placed',
+  paymentMethod: 'COD',
+  payment: false,
+  date: 1700000000000,
+}
+
+// post routes by URL: /order/list (fetch) vs /order/status (update)
+const listResponse = (orders) => ({ data: { success: true, orders } })
+
+describe('Admin Order Page Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    axios.post.mockImplementation((url) => {
+      if (url.endsWith('/api/order/list')) {
+        return Promise.resolve(listResponse([{ ...baseOrder }]))
+      }
+      if (url.endsWith('/api/order/status')) {
+        return Promise.resolve({
+          data: { success: true, message: 'Status updated' },
+        })
+      }
+      return Promise.resolve({ data: { success: true } })
+    })
+  })
+
+  it('fetches all orders with the auth header on mount', async () => {
+    render(<Order token='tkn' />)
+
+    await waitFor(() => {
+      const call = axios.post.mock.calls.find(([u]) =>
+        u.endsWith('/api/order/list')
+      )
+      expect(call).toBeTruthy()
+      expect(call[2]).toEqual({ headers: { Authorization: 'Bearer tkn' } })
+    })
+    expect(await screen.findByText(/Shirt x 1/)).toBeInTheDocument()
+  })
+
+  it('shows an error toast when the fetch is unsuccessful', async () => {
+    axios.post.mockResolvedValue({
+      data: { success: false, message: 'Forbidden' },
+    })
+    const { toast } = await import('react-toastify')
+    render(<Order token='tkn' />)
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Forbidden'))
+  })
+
+  it('shows an error toast when the fetch request rejects', async () => {
+    axios.post.mockRejectedValue(new Error('Network Error'))
+    const { toast } = await import('react-toastify')
+    render(<Order token='tkn' />)
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
+    )
+  })
+
+  it('updates status via the API and refetches on change', async () => {
+    const { toast } = await import('react-toastify')
+    render(<Order token='tkn' />)
+    await screen.findByText(/Shirt x 1/)
+
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'Shipped' },
+    })
+
+    await waitFor(() => {
+      const call = axios.post.mock.calls.find(([u]) =>
+        u.endsWith('/api/order/status')
+      )
+      expect(call[1]).toEqual({ orderId: 'o1', status: 'Shipped' })
+      expect(call[2]).toEqual({ headers: { Authorization: 'Bearer tkn' } })
+    })
+    expect(toast.success).toHaveBeenCalledWith('Status updated')
+
+    // status change triggers a refetch of the list
+    await waitFor(() => {
+      const listCalls = axios.post.mock.calls.filter(([u]) =>
+        u.endsWith('/api/order/list')
+      )
+      expect(listCalls.length).toBe(2)
+    })
+  })
+
+  it('shows an error toast when the status update rejects', async () => {
+    axios.post.mockImplementation((url) => {
+      if (url.endsWith('/api/order/list')) {
+        return Promise.resolve(listResponse([{ ...baseOrder }]))
+      }
+      return Promise.reject(new Error('Network Error'))
+    })
+    const { toast } = await import('react-toastify')
+    render(<Order token='tkn' />)
+    await screen.findByText(/Shirt x 1/)
+
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'Delivered' },
+    })
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Network Error')
+    )
+  })
+})

--- a/admin/src/pages/Order.test.jsx
+++ b/admin/src/pages/Order.test.jsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import Order from './Order'
+
+vi.mock('../App', () => ({
+  backendUrl: 'http://localhost:1001',
+  currency: '$',
+}))
+
+vi.mock('axios')
+vi.mock('react-toastify', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+const makeOrder = (overrides = {}) => ({
+  _id: 'o1',
+  items: [
+    { name: 'Shirt', quantity: 2, size: 'M' },
+    { name: 'Hat', quantity: 1, size: 'L' },
+  ],
+  amount: 210,
+  address: {
+    firstName: 'Jane',
+    lastName: 'Doe',
+    street: '1 Main St',
+    city: 'Town',
+    state: 'ST',
+    country: 'US',
+    zipcode: '12345',
+    phone: '555-1234',
+  },
+  status: 'Order Placed',
+  paymentMethod: 'COD',
+  payment: false,
+  date: 1700000000000,
+  ...overrides,
+})
+
+describe('Admin Order Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    axios.post.mockResolvedValue({
+      data: { success: true, orders: [makeOrder()] },
+    })
+  })
+
+  it('does not fetch when no token is set', async () => {
+    render(<Order token='' />)
+    await waitFor(() => {})
+    expect(axios.post).not.toHaveBeenCalled()
+  })
+
+  it('renders the static heading', async () => {
+    render(<Order token='tkn' />)
+    expect(await screen.findByText('Order Page')).toBeInTheDocument()
+  })
+
+  it('renders order items, customer name and address', async () => {
+    render(<Order token='tkn' />)
+
+    expect(await screen.findByText(/Shirt x 2/)).toBeInTheDocument()
+    expect(screen.getByText(/Hat x 1/)).toBeInTheDocument()
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('1 Main St,')).toBeInTheDocument()
+    expect(screen.getByText('555-1234')).toBeInTheDocument()
+  })
+
+  it('renders item count, payment method, pending status and amount', async () => {
+    render(<Order token='tkn' />)
+    await screen.findByText('Order Page')
+
+    expect(screen.getByText('Items : 2')).toBeInTheDocument()
+    expect(screen.getByText('Method : COD')).toBeInTheDocument()
+    expect(screen.getByText('Payment : Pending')).toBeInTheDocument()
+    expect(screen.getByText(/\$ 210/)).toBeInTheDocument()
+  })
+
+  it("shows 'Done' when payment is true", async () => {
+    axios.post.mockResolvedValue({
+      data: { success: true, orders: [makeOrder({ payment: true })] },
+    })
+    render(<Order token='tkn' />)
+
+    expect(await screen.findByText('Payment : Done')).toBeInTheDocument()
+  })
+
+  it('renders the status select reflecting the order status', async () => {
+    render(<Order token='tkn' />)
+    await screen.findByText('Order Page')
+
+    const select = screen.getByRole('combobox')
+    expect(select).toHaveValue('Order Placed')
+  })
+})

--- a/admin/vite.config.js
+++ b/admin/vite.config.js
@@ -18,7 +18,6 @@ export default defineConfig({
       exclude: [
         'src/main.jsx',
         'src/setupTests.js',
-        'src/App.jsx',
         'src/assets/**',
         'src/**/*.test.{js,jsx}',
       ],


### PR DESCRIPTION
## Problem
The **admin panel** had almost no test coverage — only `Login` was tested. The three pages (Add, List, Order), the Navbar/SideBar shell, and the `App` auth-gate/routing were all unverified. There was also no CI workflow posting an admin coverage report on PRs (backend and frontend both have one).

## Solution
Unit + integration tests for the entire admin frontend, plus a CI workflow that posts an **Admin Coverage Report** comment on every PR (mirroring the backend/frontend setup). 11 test files, 52 tests.

### Pages
| File | Type | Tests |
|------|------|-------|
| `pages/Add.test.jsx` | unit | 6 — form fields, size options, name/price typing, size toggle, bestseller checkbox |
| `pages/Add.integration.test.jsx` | integration | 5 — FormData + auth POST, category/subCategory/image append, success clears fields, `success:false` toast, reject toast |
| `pages/List.test.jsx` | unit | 4 — header labels, product rows, images, empty list |
| `pages/List.integration.test.jsx` | integration | 6 — fetch on mount, fetch-error toast, remove w/ auth + refetch, fetch reject, remove reject, remove-fail no refetch |
| `pages/Order.test.jsx` | unit | 6 — token gate, heading, items/address, count/method/payment/amount, "Done" state, status select |
| `pages/Order.integration.test.jsx` | integration | 5 — fetch w/ auth, fetch-error toast, fetch reject, status update + refetch, status-error toast |

### Components & App shell
| File | Type | Tests |
|------|------|-------|
| `components/Navbar.test.jsx` | unit | 2 — renders logo + Logout button; Logout → `setToken('')` |
| `components/SideBar.test.jsx` | unit | 2 — renders 3 nav labels; each links to `/add`, `/list`, `/order` |
| `App.test.jsx` | unit | 5 — auth gate (Login vs dashboard), login persists token, logout clears token, 401 interceptor clears token + toast |
| `App.integration.test.jsx` | integration | 4 — real Navbar + SideBar render together, SideBar link navigates and mounts the matching page, logout returns to real Login, no-token → Login only |

## CI workflow
- Added `.github/workflows/admin-tests.yml` (mirrors `frontend-tests.yml`): runs `npm run test:coverage` in `./admin` on PRs touching `admin/**` and posts an **Admin Coverage Report** comment via the existing `.github/scripts/post-coverage-comment.js`.




🤖 Generated with [Claude Code](https://claude.com/claude-code)
