### PR TITLE
feat(tests): admin BE tests

### DIFF
--- a/backend/controllers/allOrders.test.js
+++ b/backend/controllers/allOrders.test.js
@@ -1,0 +1,65 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// ─── Mock setup ───────────────────────────────────────────────────────────────
+
+const MockOrderModel = jest.fn()
+MockOrderModel.find = jest.fn()
+
+jest.unstable_mockModule('../models/orderModel.js', () => ({
+  default: MockOrderModel,
+}))
+
+jest.unstable_mockModule('../models/userModel.js', () => ({
+  default: { findByIdAndUpdate: jest.fn() },
+}))
+
+// orderController instantiates `new Stripe(...)` at module load
+jest.unstable_mockModule('stripe', () => ({
+  default: jest.fn(() => ({ checkout: { sessions: { create: jest.fn() } } })),
+}))
+
+// ─── Dynamic imports ──────────────────────────────────────────────────────────
+
+const { allOrders } = await import('./orderController.js')
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeRes = () => ({ json: jest.fn(), status: jest.fn().mockReturnThis() })
+
+// ─── allOrders ────────────────────────────────────────────────────────────────
+
+describe('allOrders', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns every order with success: true', async () => {
+    const orders = [{ _id: 'o1' }, { _id: 'o2' }]
+    MockOrderModel.find.mockResolvedValue(orders)
+
+    const res = makeRes()
+    await allOrders({}, res)
+
+    expect(MockOrderModel.find).toHaveBeenCalledWith()
+    expect(res.json).toHaveBeenCalledWith({ success: true, orders })
+  })
+
+  it('returns an empty list when there are no orders', async () => {
+    MockOrderModel.find.mockResolvedValue([])
+
+    const res = makeRes()
+    await allOrders({}, res)
+
+    expect(res.json).toHaveBeenCalledWith({ success: true, orders: [] })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    MockOrderModel.find.mockRejectedValue(new Error('DB error'))
+
+    const res = makeRes()
+    await allOrders({}, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'DB error',
+    })
+  })
+})

--- a/backend/controllers/updateStatus.test.js
+++ b/backend/controllers/updateStatus.test.js
@@ -1,0 +1,60 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// ─── Mock setup ───────────────────────────────────────────────────────────────
+
+const MockOrderModel = jest.fn()
+MockOrderModel.findByIdAndUpdate = jest.fn()
+
+jest.unstable_mockModule('../models/orderModel.js', () => ({
+  default: MockOrderModel,
+}))
+
+jest.unstable_mockModule('../models/userModel.js', () => ({
+  default: { findByIdAndUpdate: jest.fn() },
+}))
+
+// orderController instantiates `new Stripe(...)` at module load
+jest.unstable_mockModule('stripe', () => ({
+  default: jest.fn(() => ({ checkout: { sessions: { create: jest.fn() } } })),
+}))
+
+// ─── Dynamic imports ──────────────────────────────────────────────────────────
+
+const { updateStatus } = await import('./orderController.js')
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeRes = () => ({ json: jest.fn(), status: jest.fn().mockReturnThis() })
+
+// ─── updateStatus ─────────────────────────────────────────────────────────────
+
+describe('updateStatus', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('updates the order status and returns success', async () => {
+    MockOrderModel.findByIdAndUpdate.mockResolvedValue()
+
+    const res = makeRes()
+    await updateStatus({ body: { orderId: 'o1', status: 'Shipped' } }, res)
+
+    expect(MockOrderModel.findByIdAndUpdate).toHaveBeenCalledWith('o1', {
+      status: 'Shipped',
+    })
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Status updated',
+    })
+  })
+
+  it('returns success: false with error message on failure', async () => {
+    MockOrderModel.findByIdAndUpdate.mockRejectedValue(new Error('DB error'))
+
+    const res = makeRes()
+    await updateStatus({ body: { orderId: 'o1', status: 'Shipped' } }, res)
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'DB error',
+    })
+  })
+})

--- a/backend/routes/allOrders.integration.test.js
+++ b/backend/routes/allOrders.integration.test.js
@@ -1,0 +1,105 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  jest,
+} from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+
+// ─── Env before importing the route (Stripe is constructed at module load) ─────
+
+process.env.JWT_SECRET = 'test-secret'
+process.env.STRIPE_SECRET_KEY = 'sk_test_dummy'
+
+const { default: orderRouter } = await import('./orderRoute.js')
+const { default: orderModel } = await import('../models/orderModel.js')
+
+// ─── Test app ─────────────────────────────────────────────────────────────────
+
+const app = express()
+app.use(express.json())
+app.use('/api/order', orderRouter)
+
+// ─── Database setup ───────────────────────────────────────────────────────────
+
+let mongoServer
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create()
+  await mongoose.connect(mongoServer.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+afterEach(async () => {
+  await orderModel.deleteMany({})
+  jest.clearAllMocks()
+})
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const adminToken = () =>
+  jwt.sign({ id: 'admin-id', role: 'admin' }, process.env.JWT_SECRET, {
+    expiresIn: '1d',
+  })
+
+const userToken = () =>
+  jwt.sign({ id: 'user-id', role: 'user' }, process.env.JWT_SECRET, {
+    expiresIn: '1d',
+  })
+
+const seedOrder = (overrides = {}) =>
+  orderModel.create({
+    userId: 'user-1',
+    items: [{ name: 'Shirt', quantity: 1, price: 100, size: 'M' }],
+    amount: 110,
+    address: { firstName: 'Jane' },
+    paymentMethod: 'COD',
+    payment: false,
+    date: Date.now(),
+    ...overrides,
+  })
+
+// ─── POST /api/order/list ─────────────────────────────────────────────────────
+
+describe('POST /api/order/list (allOrders)', () => {
+  it('returns every order for an admin token', async () => {
+    await seedOrder({ userId: 'user-1' })
+    await seedOrder({ userId: 'user-2' })
+
+    const res = await request(app)
+      .post('/api/order/list')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({})
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.orders).toHaveLength(2)
+  })
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app).post('/api/order/list').send({})
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+
+  it('returns 403 with a non-admin token', async () => {
+    const res = await request(app)
+      .post('/api/order/list')
+      .set('Authorization', `Bearer ${userToken()}`)
+      .send({})
+
+    expect(res.status).toBe(403)
+    expect(res.body.success).toBe(false)
+  })
+})

--- a/backend/routes/updateStatus.integration.test.js
+++ b/backend/routes/updateStatus.integration.test.js
@@ -1,0 +1,117 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  jest,
+} from '@jest/globals'
+import { MongoMemoryServer } from 'mongodb-memory-server'
+import mongoose from 'mongoose'
+import request from 'supertest'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+
+// ─── Env before importing the route (Stripe is constructed at module load) ─────
+
+process.env.JWT_SECRET = 'test-secret'
+process.env.STRIPE_SECRET_KEY = 'sk_test_dummy'
+
+const { default: orderRouter } = await import('./orderRoute.js')
+const { default: orderModel } = await import('../models/orderModel.js')
+
+// ─── Test app ─────────────────────────────────────────────────────────────────
+
+const app = express()
+app.use(express.json())
+app.use('/api/order', orderRouter)
+
+// ─── Database setup ───────────────────────────────────────────────────────────
+
+let mongoServer
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create()
+  await mongoose.connect(mongoServer.getUri())
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+afterEach(async () => {
+  await orderModel.deleteMany({})
+  jest.clearAllMocks()
+})
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const adminToken = () =>
+  jwt.sign({ id: 'admin-id', role: 'admin' }, process.env.JWT_SECRET, {
+    expiresIn: '1d',
+  })
+
+const userToken = () =>
+  jwt.sign({ id: 'user-id', role: 'user' }, process.env.JWT_SECRET, {
+    expiresIn: '1d',
+  })
+
+const seedOrder = () =>
+  orderModel.create({
+    userId: 'user-1',
+    items: [{ name: 'Shirt', quantity: 1, price: 100, size: 'M' }],
+    amount: 110,
+    address: { firstName: 'Jane' },
+    status: 'Order Placed',
+    paymentMethod: 'COD',
+    payment: false,
+    date: Date.now(),
+  })
+
+// ─── POST /api/order/status ───────────────────────────────────────────────────
+
+describe('POST /api/order/status (updateStatus)', () => {
+  it('updates the order status in the DB for an admin token', async () => {
+    const order = await seedOrder()
+
+    const res = await request(app)
+      .post('/api/order/status')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ orderId: order._id.toString(), status: 'Shipped' })
+
+    expect(res.body.success).toBe(true)
+    expect(res.body.message).toBe('Status updated')
+
+    const updated = await orderModel.findById(order._id)
+    expect(updated.status).toBe('Shipped')
+  })
+
+  it('returns 401 without a token', async () => {
+    const order = await seedOrder()
+
+    const res = await request(app)
+      .post('/api/order/status')
+      .send({ orderId: order._id.toString(), status: 'Shipped' })
+
+    expect(res.status).toBe(401)
+    expect(res.body.success).toBe(false)
+  })
+
+  it('returns 403 with a non-admin token', async () => {
+    const order = await seedOrder()
+
+    const res = await request(app)
+      .post('/api/order/status')
+      .set('Authorization', `Bearer ${userToken()}`)
+      .send({ orderId: order._id.toString(), status: 'Shipped' })
+
+    expect(res.status).toBe(403)
+    expect(res.body.success).toBe(false)
+
+    // status unchanged
+    const untouched = await orderModel.findById(order._id)
+    expect(untouched.status).toBe('Order Placed')
+  })
+})


### PR DESCRIPTION
## Problem
The two **admin** order handlers in `orderController.js` — `allOrders` and `updateStatus` — had no test coverage. These power the admin order dashboard.

## Solution
Unit + integration tests for both admin handlers. 4 new files, 11 tests.

| File | Type | Tests |
|------|------|-------|
| `controllers/allOrders.test.js` | unit | 3 — returns all orders, empty list, error path (models mocked) |
| `controllers/updateStatus.test.js` | unit | 2 — updates status + success message, error path |
| `routes/allOrders.integration.test.js` | integration | 3 — admin token returns all orders, 401 no token, 403 non-admin token |
| `routes/updateStatus.integration.test.js` | integration | 3 — admin token updates status in DB, 401 no token, 403 non-admin (status unchanged) |

## What these handlers do
- **`allOrders`** (`POST /api/order/list`, adminAuth) — returns **every** order in the shop (unfiltered) for the admin dashboard.
- **`updateStatus`** (`POST /api/order/status`, adminAuth) — sets an order's `status` (Packing / Shipped / Delivered / …).

Both are consumed by the admin `Order.jsx` page (tested separately in the admin PR). The admin frontend tests mock the network, so this PR covers the other half — that the server behaves correctly given those requests.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
