### PR TITLE
feat(e2e): guest user tests

### DIFF
--- a/backend/scripts/seed-data.json
+++ b/backend/scripts/seed-data.json
@@ -3,520 +3,909 @@
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 100,
-    "images": ["p_img1.png"],
+    "images": [
+      "p_img1.png"
+    ],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L"],
+    "sizes": [
+      "S",
+      "M",
+      "L"
+    ],
     "bestSeller": true
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 200,
-    "images": ["p_img2_1.png", "p_img2_2.png", "p_img2_3.png", "p_img2_4.png"],
+    "images": [
+      "p_img2_1.png",
+      "p_img2_2.png",
+      "p_img2_3.png",
+      "p_img2_4.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["M", "L", "XL"],
+    "sizes": [
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": true
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 220,
-    "images": ["p_img3.png"],
+    "images": [
+      "p_img3.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "L", "XL"],
+    "sizes": [
+      "S",
+      "L",
+      "XL"
+    ],
     "bestSeller": true
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 110,
-    "images": ["p_img4.png"],
+    "images": [
+      "p_img4.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "XXL"],
+    "sizes": [
+      "S",
+      "M",
+      "XXL"
+    ],
     "bestSeller": true
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 130,
-    "images": ["p_img5.png"],
+    "images": [
+      "p_img5.png"
+    ],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": ["M", "L", "XL"],
+    "sizes": [
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": true
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 140,
-    "images": ["p_img6.png"],
+    "images": [
+      "p_img6.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "L", "XL"],
+    "sizes": [
+      "S",
+      "L",
+      "XL"
+    ],
     "bestSeller": true
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 190,
-    "images": ["p_img7.png"],
+    "images": [
+      "p_img7.png"
+    ],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "L", "XL"],
+    "sizes": [
+      "S",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 140,
-    "images": ["p_img8.png"],
+    "images": [
+      "p_img8.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 100,
-    "images": ["p_img9.png"],
+    "images": [
+      "p_img9.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["M", "L", "XL"],
+    "sizes": [
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 110,
-    "images": ["p_img10.png"],
+    "images": [
+      "p_img10.png"
+    ],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "L", "XL"],
+    "sizes": [
+      "S",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 120,
-    "images": ["p_img11.png"],
+    "images": [
+      "p_img11.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L"],
+    "sizes": [
+      "S",
+      "M",
+      "L"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 150,
-    "images": ["p_img12.png"],
+    "images": [
+      "p_img12.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 130,
-    "images": ["p_img13.png"],
+    "images": [
+      "p_img13.png"
+    ],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 160,
-    "images": ["p_img14.png"],
+    "images": [
+      "p_img14.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 140,
-    "images": ["p_img15.png"],
+    "images": [
+      "p_img15.png"
+    ],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 170,
-    "images": ["p_img16.png"],
+    "images": [
+      "p_img16.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 150,
-    "images": ["p_img17.png"],
+    "images": [
+      "p_img17.png"
+    ],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 180,
-    "images": ["p_img18.png"],
+    "images": [
+      "p_img18.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 160,
-    "images": ["p_img19.png"],
+    "images": [
+      "p_img19.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Palazzo Pants with Waist Belt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 190,
-    "images": ["p_img20.png"],
+    "images": [
+      "p_img20.png"
+    ],
     "category": "Women",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 170,
-    "images": ["p_img21.png"],
+    "images": [
+      "p_img21.png"
+    ],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Palazzo Pants with Waist Belt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 200,
-    "images": ["p_img22.png"],
+    "images": [
+      "p_img22.png"
+    ],
     "category": "Women",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 180,
-    "images": ["p_img23.png"],
+    "images": [
+      "p_img23.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 210,
-    "images": ["p_img24.png"],
+    "images": [
+      "p_img24.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 190,
-    "images": ["p_img25.png"],
+    "images": [
+      "p_img25.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 220,
-    "images": ["p_img26.png"],
+    "images": [
+      "p_img26.png"
+    ],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 200,
-    "images": ["p_img27.png"],
+    "images": [
+      "p_img27.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 230,
-    "images": ["p_img28.png"],
+    "images": [
+      "p_img28.png"
+    ],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 210,
-    "images": ["p_img29.png"],
+    "images": [
+      "p_img29.png"
+    ],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 240,
-    "images": ["p_img30.png"],
+    "images": [
+      "p_img30.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 220,
-    "images": ["p_img31.png"],
+    "images": [
+      "p_img31.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 250,
-    "images": ["p_img32.png"],
+    "images": [
+      "p_img32.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 230,
-    "images": ["p_img33.png"],
+    "images": [
+      "p_img33.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 260,
-    "images": ["p_img34.png"],
+    "images": [
+      "p_img34.png"
+    ],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 240,
-    "images": ["p_img35.png"],
+    "images": [
+      "p_img35.png"
+    ],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 270,
-    "images": ["p_img36.png"],
+    "images": [
+      "p_img36.png"
+    ],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 250,
-    "images": ["p_img37.png"],
+    "images": [
+      "p_img37.png"
+    ],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 280,
-    "images": ["p_img38.png"],
+    "images": [
+      "p_img38.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Printed Plain Cotton Shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 260,
-    "images": ["p_img39.png"],
+    "images": [
+      "p_img39.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 290,
-    "images": ["p_img40.png"],
+    "images": [
+      "p_img40.png"
+    ],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 270,
-    "images": ["p_img41.png"],
+    "images": [
+      "p_img41.png"
+    ],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 300,
-    "images": ["p_img42.png"],
+    "images": [
+      "p_img42.png"
+    ],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 280,
-    "images": ["p_img43.png"],
+    "images": [
+      "p_img43.png"
+    ],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 310,
-    "images": ["p_img44.png"],
+    "images": [
+      "p_img44.png"
+    ],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 290,
-    "images": ["p_img45.png"],
+    "images": [
+      "p_img45.png"
+    ],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 320,
-    "images": ["p_img46.png"],
+    "images": [
+      "p_img46.png"
+    ],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 300,
-    "images": ["p_img47.png"],
+    "images": [
+      "p_img47.png"
+    ],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 330,
-    "images": ["p_img48.png"],
+    "images": [
+      "p_img48.png"
+    ],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 310,
-    "images": ["p_img49.png"],
+    "images": [
+      "p_img49.png"
+    ],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 340,
-    "images": ["p_img50.png"],
+    "images": [
+      "p_img50.png"
+    ],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 320,
-    "images": ["p_img51.png"],
+    "images": [
+      "p_img51.png"
+    ],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 350,
-    "images": ["p_img52.png"],
+    "images": [
+      "p_img52.png"
+    ],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": ["S", "M", "L", "XL"],
+    "sizes": [
+      "S",
+      "M",
+      "L",
+      "XL"
+    ],
+    "bestSeller": false
+  },
+  {
+    "name": "E2E Guest Cart Item One",
+    "description": "Reserved for Cypress e2e guest-cart tests. Do not rename or remove.",
+    "price": 111,
+    "images": [
+      "p_img1.png"
+    ],
+    "category": "Women",
+    "subCategory": "Topwear",
+    "sizes": [
+      "S",
+      "M",
+      "L"
+    ],
+    "bestSeller": false
+  },
+  {
+    "name": "E2E Guest Cart Item Two",
+    "description": "Reserved for Cypress e2e guest-cart tests. Do not rename or remove.",
+    "price": 222,
+    "images": [
+      "p_img2_1.png"
+    ],
+    "category": "Men",
+    "subCategory": "Topwear",
+    "sizes": [
+      "S",
+      "M",
+      "L"
+    ],
     "bestSeller": false
   }
 ]

--- a/backend/scripts/seed-data.json
+++ b/backend/scripts/seed-data.json
@@ -3,909 +3,540 @@
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 100,
-    "images": [
-      "p_img1.png"
-    ],
+    "images": ["p_img1.png"],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L"
-    ],
+    "sizes": ["S", "M", "L"],
     "bestSeller": true
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 200,
-    "images": [
-      "p_img2_1.png",
-      "p_img2_2.png",
-      "p_img2_3.png",
-      "p_img2_4.png"
-    ],
+    "images": ["p_img2_1.png", "p_img2_2.png", "p_img2_3.png", "p_img2_4.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["M", "L", "XL"],
     "bestSeller": true
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 220,
-    "images": [
-      "p_img3.png"
-    ],
+    "images": ["p_img3.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "L", "XL"],
     "bestSeller": true
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 110,
-    "images": [
-      "p_img4.png"
-    ],
+    "images": ["p_img4.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "XXL"
-    ],
+    "sizes": ["S", "M", "XXL"],
     "bestSeller": true
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 130,
-    "images": [
-      "p_img5.png"
-    ],
+    "images": ["p_img5.png"],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": [
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["M", "L", "XL"],
     "bestSeller": true
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 140,
-    "images": [
-      "p_img6.png"
-    ],
+    "images": ["p_img6.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "L", "XL"],
     "bestSeller": true
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 190,
-    "images": [
-      "p_img7.png"
-    ],
+    "images": ["p_img7.png"],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 140,
-    "images": [
-      "p_img8.png"
-    ],
+    "images": ["p_img8.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 100,
-    "images": [
-      "p_img9.png"
-    ],
+    "images": ["p_img9.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 110,
-    "images": [
-      "p_img10.png"
-    ],
+    "images": ["p_img10.png"],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 120,
-    "images": [
-      "p_img11.png"
-    ],
+    "images": ["p_img11.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L"
-    ],
+    "sizes": ["S", "M", "L"],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 150,
-    "images": [
-      "p_img12.png"
-    ],
+    "images": ["p_img12.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 130,
-    "images": [
-      "p_img13.png"
-    ],
+    "images": ["p_img13.png"],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 160,
-    "images": [
-      "p_img14.png"
-    ],
+    "images": ["p_img14.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 140,
-    "images": [
-      "p_img15.png"
-    ],
+    "images": ["p_img15.png"],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 170,
-    "images": [
-      "p_img16.png"
-    ],
+    "images": ["p_img16.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Tapered Fit Flat-Front Trousers",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 150,
-    "images": [
-      "p_img17.png"
-    ],
+    "images": ["p_img17.png"],
     "category": "Men",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 180,
-    "images": [
-      "p_img18.png"
-    ],
+    "images": ["p_img18.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 160,
-    "images": [
-      "p_img19.png"
-    ],
+    "images": ["p_img19.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Palazzo Pants with Waist Belt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 190,
-    "images": [
-      "p_img20.png"
-    ],
+    "images": ["p_img20.png"],
     "category": "Women",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 170,
-    "images": [
-      "p_img21.png"
-    ],
+    "images": ["p_img21.png"],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Palazzo Pants with Waist Belt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 200,
-    "images": [
-      "p_img22.png"
-    ],
+    "images": ["p_img22.png"],
     "category": "Women",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 180,
-    "images": [
-      "p_img23.png"
-    ],
+    "images": ["p_img23.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 210,
-    "images": [
-      "p_img24.png"
-    ],
+    "images": ["p_img24.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 190,
-    "images": [
-      "p_img25.png"
-    ],
+    "images": ["p_img25.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 220,
-    "images": [
-      "p_img26.png"
-    ],
+    "images": ["p_img26.png"],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 200,
-    "images": [
-      "p_img27.png"
-    ],
+    "images": ["p_img27.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 230,
-    "images": [
-      "p_img28.png"
-    ],
+    "images": ["p_img28.png"],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 210,
-    "images": [
-      "p_img29.png"
-    ],
+    "images": ["p_img29.png"],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 240,
-    "images": [
-      "p_img30.png"
-    ],
+    "images": ["p_img30.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 220,
-    "images": [
-      "p_img31.png"
-    ],
+    "images": ["p_img31.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 250,
-    "images": [
-      "p_img32.png"
-    ],
+    "images": ["p_img32.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Girls Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 230,
-    "images": [
-      "p_img33.png"
-    ],
+    "images": ["p_img33.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 260,
-    "images": [
-      "p_img34.png"
-    ],
+    "images": ["p_img34.png"],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 240,
-    "images": [
-      "p_img35.png"
-    ],
+    "images": ["p_img35.png"],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 270,
-    "images": [
-      "p_img36.png"
-    ],
+    "images": ["p_img36.png"],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Round Neck Cotton Top",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 250,
-    "images": [
-      "p_img37.png"
-    ],
+    "images": ["p_img37.png"],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 280,
-    "images": [
-      "p_img38.png"
-    ],
+    "images": ["p_img38.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Printed Plain Cotton Shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 260,
-    "images": [
-      "p_img39.png"
-    ],
+    "images": ["p_img39.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 290,
-    "images": [
-      "p_img40.png"
-    ],
+    "images": ["p_img40.png"],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 270,
-    "images": [
-      "p_img41.png"
-    ],
+    "images": ["p_img41.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Boy Round Neck Pure Cotton T-shirt",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 300,
-    "images": [
-      "p_img42.png"
-    ],
+    "images": ["p_img42.png"],
     "category": "Kids",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 280,
-    "images": [
-      "p_img43.png"
-    ],
+    "images": ["p_img43.png"],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 310,
-    "images": [
-      "p_img44.png"
-    ],
+    "images": ["p_img44.png"],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 290,
-    "images": [
-      "p_img45.png"
-    ],
+    "images": ["p_img45.png"],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 320,
-    "images": [
-      "p_img46.png"
-    ],
+    "images": ["p_img46.png"],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 300,
-    "images": [
-      "p_img47.png"
-    ],
+    "images": ["p_img47.png"],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 330,
-    "images": [
-      "p_img48.png"
-    ],
+    "images": ["p_img48.png"],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 310,
-    "images": [
-      "p_img49.png"
-    ],
+    "images": ["p_img49.png"],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Kid Tapered Slim Fit Trouser",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 340,
-    "images": [
-      "p_img50.png"
-    ],
+    "images": ["p_img50.png"],
     "category": "Kids",
     "subCategory": "Bottomwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Women Zip-Front Relaxed Fit Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 320,
-    "images": [
-      "p_img51.png"
-    ],
+    "images": ["p_img51.png"],
     "category": "Women",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "Men Slim Fit Relaxed Denim Jacket",
     "description": "A lightweight, usually knitted, pullover shirt, close-fitting and with a round neckline and short sleeves, worn as an undershirt or outer garment.",
     "price": 350,
-    "images": [
-      "p_img52.png"
-    ],
+    "images": ["p_img52.png"],
     "category": "Men",
     "subCategory": "Winterwear",
-    "sizes": [
-      "S",
-      "M",
-      "L",
-      "XL"
-    ],
+    "sizes": ["S", "M", "L", "XL"],
     "bestSeller": false
   },
   {
     "name": "E2E Guest Cart Item One",
     "description": "Reserved for Cypress e2e guest-cart tests. Do not rename or remove.",
     "price": 111,
-    "images": [
-      "p_img1.png"
-    ],
+    "images": ["p_img1.png"],
     "category": "Women",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L"
-    ],
+    "sizes": ["S", "M", "L"],
     "bestSeller": false
   },
   {
     "name": "E2E Guest Cart Item Two",
     "description": "Reserved for Cypress e2e guest-cart tests. Do not rename or remove.",
     "price": 222,
-    "images": [
-      "p_img2_1.png"
-    ],
+    "images": ["p_img2_1.png"],
     "category": "Men",
     "subCategory": "Topwear",
-    "sizes": [
-      "S",
-      "M",
-      "L"
-    ],
+    "sizes": ["S", "M", "L"],
     "bestSeller": false
   }
 ]

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,11 +1,15 @@
 const { defineConfig } = require('cypress')
+const { getSeedProductCounts, getSeedProductByName } = require('./cypress/tasks/seedData.cjs')
 
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5173',
-    // setupNodeEvents(on, config) {
-    // implement node event listeners here
-    //  },
+    setupNodeEvents(on) {
+      on('task', {
+        getSeedProductCounts,
+        getSeedProductByName,
+      })
+    },
   },
   env: {
     apiUrl: 'http://localhost:4000',

--- a/cypress/e2e/store/guest_checkout.spec.cy.ts
+++ b/cypress/e2e/store/guest_checkout.spec.cy.ts
@@ -1,0 +1,126 @@
+const PRODUCT_ONE = 'E2E Guest Cart Item One'
+const PRODUCT_TWO = 'E2E Guest Cart Item Two'
+const DELIVERY_FEE = 10
+
+describe('Guest user checkout flow', () => {
+  it('Guest user is able to add items to cart', () => {
+    let productOnePrice: number
+    let productTwoPrice: number
+
+    cy.getSeedProduct(PRODUCT_ONE).then((p) => {
+      productOnePrice = p.price
+    })
+    cy.getSeedProduct(PRODUCT_TWO).then((p) => {
+      productTwoPrice = p.price
+    })
+
+    cy.visit('/collection')
+
+    cy.get('[data-testid="product-card"]').should('have.length.greaterThan', 0)
+
+    // first product, size S
+    cy.get(
+      `[data-testid="product-card"][data-product-name="${PRODUCT_ONE}"]`
+    ).click()
+    cy.get('[data-testid="product-size-S"]').click()
+    cy.get('[data-testid="add-to-cart-button"]').click()
+
+    cy.get('[data-testid="navbar-cart-count"]').should('have.text', '1')
+
+    // second product, size L — navigate via the nav link (client-side route
+    // change) instead of cy.visit, which would do a full reload and wipe the
+    // guest cart (cartItems only lives in React state, never persisted - code related issue)
+    cy.get('[data-testid="navbar-collection-link"]').click()
+    cy.get(
+      `[data-testid="product-card"][data-product-name="${PRODUCT_TWO}"]`
+    ).click()
+    cy.get('[data-testid="product-size-L"]').click()
+    cy.get('[data-testid="add-to-cart-button"]').click()
+
+    cy.get('[data-testid="navbar-cart-count"]').should('have.text', '2')
+
+    // navbar link, not cy.visit — same full-reload/cart-wipe reason as above
+    cy.get('[data-testid="navbar-cart-link"]').click()
+
+    cy.get('[data-testid="cart-item"]').should('have.length', 2)
+
+    // bump the first product's quantity from 1 to 2 in cart
+    cy.get('[data-testid="cart-item"]')
+      .contains('[data-testid="cart-item-name"]', PRODUCT_ONE)
+      .parents('[data-testid="cart-item"]')
+      .find('[data-testid="cart-item-quantity"]')
+      .clear()
+      .type('2')
+
+    cy.get('[data-testid="navbar-cart-count"]').should('have.text', '3')
+
+    // verify final cart contents: product/size/quantity/price per row
+    cy.get('[data-testid="cart-item"]')
+      .contains('[data-testid="cart-item-name"]', PRODUCT_ONE)
+      .parents('[data-testid="cart-item"]')
+      .within(() => {
+        cy.get('[data-testid="cart-item-size"]').should('have.text', 'S')
+        cy.get('[data-testid="cart-item-quantity"]').should('have.value', '2')
+        cy.get('[data-testid="cart-item-price"]').then(($price) => {
+          expect($price.text()).to.contain(String(productOnePrice))
+        })
+      })
+
+    cy.get('[data-testid="cart-item"]')
+      .contains('[data-testid="cart-item-name"]', PRODUCT_TWO)
+      .parents('[data-testid="cart-item"]')
+      .within(() => {
+        cy.get('[data-testid="cart-item-size"]').should('have.text', 'L')
+        cy.get('[data-testid="cart-item-quantity"]').should('have.value', '1')
+        cy.get('[data-testid="cart-item-price"]').then(($price) => {
+          expect($price.text()).to.contain(String(productTwoPrice))
+        })
+      })
+
+    // subtotal/total: product one qty 2 + product two qty 1
+    cy.then(() => {
+      const expectedSubtotal = productOnePrice * 2 + productTwoPrice * 1
+      const expectedTotal = expectedSubtotal + DELIVERY_FEE
+
+      cy.get('[data-testid="cart-subtotal"]').should(
+        'have.text',
+        `$ ${expectedSubtotal}.00`
+      )
+      cy.get('[data-testid="cart-total"]').should(
+        'have.text',
+        `$ ${expectedTotal}.00`
+      )
+    })
+  })
+
+  it('Guest user is blocked from completing checkout', () => {
+    cy.visit('/collection')
+    cy.get('[data-testid="product-card"]').first().click()
+    cy.get('[data-testid^="product-size-"]').first().click()
+    cy.get('[data-testid="add-to-cart-button"]').click()
+
+    cy.visit('/cart')
+    cy.get('[data-testid="proceed-to-checkout-button"]').click()
+
+    cy.url().should('include', '/place-order')
+
+    cy.intercept('POST', '**/api/order/place').as('placeOrder')
+
+    cy.get('input[name="firstName"]').type('Guest')
+    cy.get('input[name="lastName"]').type('User')
+    cy.get('input[name="email"]').type('guest@example.com')
+    cy.get('input[name="street"]').type('123 Main St')
+    cy.get('input[name="city"]').type('Metropolis')
+    cy.get('input[name="state"]').type('NY')
+    cy.get('input[name="zipcode"]').type('10001')
+    cy.get('input[name="country"]').type('USA')
+    cy.get('input[name="phone"]').type('5551234567')
+
+    cy.get('button[type="submit"]').click()
+
+    cy.wait('@placeOrder').its('response.statusCode').should('eq', 401)
+
+    // guest is not redirected to the orders page — order was rejected
+    cy.url().should('include', '/place-order')
+  })
+})

--- a/cypress/e2e/store/product_filters.spec.cy.ts
+++ b/cypress/e2e/store/product_filters.spec.cy.ts
@@ -1,0 +1,143 @@
+import { SeedProductCounts } from '../../types'
+
+describe('Guest User Exploring the Store', () => {
+  let counts: SeedProductCounts
+
+  before(() => {
+    cy.getSeedProductCounts().then((seedCounts) => {
+      counts = seedCounts
+    })
+  })
+
+  it('Guest user can filter products by category', () => {
+    cy.visit('/collection')
+
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.category.all
+    )
+
+    cy.get('[data-testid="filter-category-men"]').check({ force: true })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.category.Men
+    )
+    cy.get('[data-testid="filter-category-men"]').uncheck({ force: true })
+
+    cy.get('[data-testid="filter-category-women"]').check({ force: true })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.category.Women
+    )
+    cy.get('[data-testid="filter-category-women"]').uncheck({ force: true })
+
+    cy.get('[data-testid="filter-category-kids"]').check({ force: true })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.category.Kids
+    )
+    cy.get('[data-testid="filter-category-kids"]').uncheck({ force: true })
+
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.category.all
+    )
+  })
+
+  it('Guest user can filter products based on type', () => {
+    cy.visit('/collection')
+
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.type.all
+    )
+
+    cy.get('[data-testid="filter-subcategory-topwear"]').check({
+      force: true,
+    })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.type.Topwear
+    )
+    cy.get('[data-testid="filter-subcategory-topwear"]').uncheck({
+      force: true,
+    })
+
+    cy.get('[data-testid="filter-subcategory-bottomwear"]').check({
+      force: true,
+    })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.type.Bottomwear
+    )
+    cy.get('[data-testid="filter-subcategory-bottomwear"]').uncheck({
+      force: true,
+    })
+
+    cy.get('[data-testid="filter-subcategory-winterwear"]').check({
+      force: true,
+    })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.type.Winterwear
+    )
+    cy.get('[data-testid="filter-subcategory-winterwear"]').uncheck({
+      force: true,
+    })
+
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.type.all
+    )
+  })
+
+  it('guest user can filter products by both category and type', () => {
+    cy.visit('/collection')
+
+    cy.get('[data-testid="filter-category-men"]').check({ force: true })
+    cy.get('[data-testid="filter-subcategory-bottomwear"]').check({
+      force: true,
+    })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.combo.MenBottomwear
+    )
+    cy.get('[data-testid="filter-category-men"]').uncheck({ force: true })
+    cy.get('[data-testid="filter-subcategory-bottomwear"]').uncheck({
+      force: true,
+    })
+
+    cy.get('[data-testid="filter-category-women"]').check({ force: true })
+    cy.get('[data-testid="filter-subcategory-winterwear"]').check({
+      force: true,
+    })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.combo.WomenWinterwear
+    )
+    cy.get('[data-testid="filter-category-women"]').uncheck({ force: true })
+    cy.get('[data-testid="filter-subcategory-winterwear"]').uncheck({
+      force: true,
+    })
+
+    cy.get('[data-testid="filter-category-women"]').check({ force: true })
+    cy.get('[data-testid="filter-category-kids"]').check({ force: true })
+    cy.get('[data-testid="filter-subcategory-topwear"]').check({
+      force: true,
+    })
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.combo.WomenKidsTopwear
+    )
+    cy.get('[data-testid="filter-category-women"]').uncheck({ force: true })
+    cy.get('[data-testid="filter-category-kids"]').uncheck({ force: true })
+    cy.get('[data-testid="filter-subcategory-topwear"]').uncheck({
+      force: true,
+    })
+
+    cy.get('[data-testid="product-card"]').should(
+      'have.length',
+      counts.category.all
+    )
+  })
+})

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,13 @@
-import { RegisterUserPayload } from '../types'
+import { RegisterUserPayload, SeedProduct, SeedProductCounts } from '../types'
 
 Cypress.Commands.add('registerUserViaApi', (user: RegisterUserPayload) => {
   return cy.request('POST', `${Cypress.env('apiUrl')}/api/user/register`, user)
+})
+
+Cypress.Commands.add('getSeedProductCounts', () => {
+  return cy.task<SeedProductCounts>('getSeedProductCounts')
+})
+
+Cypress.Commands.add('getSeedProduct', (name: string) => {
+  return cy.task<SeedProduct>('getSeedProductByName', name)
 })

--- a/cypress/tasks/seedData.cjs
+++ b/cypress/tasks/seedData.cjs
@@ -1,0 +1,59 @@
+const path = require('path')
+
+const SEED_DATA_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'backend/scripts/seed-data.json'
+)
+
+const loadSeedData = () => require(SEED_DATA_PATH)
+
+const countBy = (seedData, key, value) =>
+  seedData.filter((p) => p[key] === value).length
+
+const countCombo = (seedData, categories, subCategories) =>
+  seedData.filter(
+    (p) =>
+      categories.includes(p.category) && subCategories.includes(p.subCategory)
+  ).length
+
+const getSeedProductCounts = () => {
+  const seedData = loadSeedData()
+
+  return {
+    category: {
+      all: seedData.length,
+      Men: countBy(seedData, 'category', 'Men'),
+      Women: countBy(seedData, 'category', 'Women'),
+      Kids: countBy(seedData, 'category', 'Kids'),
+    },
+    type: {
+      all: seedData.length,
+      Topwear: countBy(seedData, 'subCategory', 'Topwear'),
+      Bottomwear: countBy(seedData, 'subCategory', 'Bottomwear'),
+      Winterwear: countBy(seedData, 'subCategory', 'Winterwear'),
+    },
+    combo: {
+      MenBottomwear: countCombo(seedData, ['Men'], ['Bottomwear']),
+      WomenWinterwear: countCombo(seedData, ['Women'], ['Winterwear']),
+      WomenKidsTopwear: countCombo(seedData, ['Women', 'Kids'], ['Topwear']),
+    },
+  }
+}
+
+const getSeedProductByName = (name) => {
+  const seedData = loadSeedData()
+  const product = seedData.find((p) => p.name === name)
+
+  if (!product) {
+    throw new Error(`No seed product found with name "${name}"`)
+  }
+
+  return product
+}
+
+module.exports = {
+  getSeedProductCounts,
+  getSeedProductByName,
+}

--- a/cypress/types/commands.d.ts
+++ b/cypress/types/commands.d.ts
@@ -1,4 +1,9 @@
-import { RegisterUserPayload, RegisterUserResponse } from './index'
+import {
+  RegisterUserPayload,
+  RegisterUserResponse,
+  SeedProduct,
+  SeedProductCounts,
+} from './index'
 
 declare global {
   namespace Cypress {
@@ -10,6 +15,18 @@ declare global {
       registerUserViaApi(
         user: RegisterUserPayload
       ): Chainable<Cypress.Response<RegisterUserResponse>>
+
+      /**
+       * Reads backend/scripts/seed-data.json (via a Node task) and returns
+       * live category/type/combo product counts — stays correct if seed data changes.
+       */
+      getSeedProductCounts(): Chainable<SeedProductCounts>
+
+      /**
+       * Reads a single product's data (incl. price) from
+       * backend/scripts/seed-data.json by exact name, via a Node task.
+       */
+      getSeedProduct(name: string): Chainable<SeedProduct>
     }
   }
 }

--- a/cypress/types/index.d.ts
+++ b/cypress/types/index.d.ts
@@ -9,3 +9,34 @@ export interface RegisterUserResponse {
   message?: string
   token?: string
 }
+
+export interface SeedProduct {
+  name: string
+  description: string
+  price: number
+  images: string[]
+  category: string
+  subCategory: string
+  sizes: string[]
+  bestSeller: boolean
+}
+
+export interface SeedProductCounts {
+  category: {
+    all: number
+    Men: number
+    Women: number
+    Kids: number
+  }
+  type: {
+    all: number
+    Topwear: number
+    Bottomwear: number
+    Winterwear: number
+  }
+  combo: {
+    MenBottomwear: number
+    WomenWinterwear: number
+    WomenKidsTopwear: number
+  }
+}

--- a/frontend/src/components/CartTotal.jsx
+++ b/frontend/src/components/CartTotal.jsx
@@ -14,7 +14,7 @@ const CartTotal = () => {
       <div className='flex flex-col gap-2 mt-2 text-sm'>
         <div className='flex justify-between'>
           <p>Subtotal</p>
-          <p>
+          <p data-testid='cart-subtotal'>
             {currency} {getCartAmount()}.00
           </p>
         </div>
@@ -28,7 +28,7 @@ const CartTotal = () => {
         <hr />
         <div className='flex justify-between'>
           <b>Total</b>
-          <b>
+          <b data-testid='cart-total'>
             {currency}{' '}
             {getCartAmount() === 0 ? 0 : getCartAmount() + delivery_fee}.00
           </b>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -33,7 +33,11 @@ const Navbar = () => {
           <p>HOME</p>
           <hr className='w-2/4 border-none h-[1.5px] bg-gray-700 hidden' />
         </NavLink>
-        <NavLink to='/collection' className='flex flex-col items-center gap-1'>
+        <NavLink
+          to='/collection'
+          className='flex flex-col items-center gap-1'
+          data-testid='navbar-collection-link'
+        >
           <p>COLLECTION</p>
           <hr className='w-2/4 border-none h-[1.5px] bg-gray-700 hidden' />
         </NavLink>
@@ -53,6 +57,7 @@ const Navbar = () => {
           className='w-5 cursor-pointer'
           onClick={() => setShowSearch(true)}
           alt=''
+          data-testid='navbar-search-icon'
         />
 
         <div className='group relative'>
@@ -90,9 +95,12 @@ const Navbar = () => {
           )}
         </div>
 
-        <Link to='/cart' className='relative'>
+        <Link to='/cart' className='relative' data-testid='navbar-cart-link'>
           <img src={assets.cart_icon} className='w-5 min-w-5' alt='' />
-          <p className='absolute right-[-5px] bottom-[-5px] w-4 text-center leading-4 bg-black text-white aspect-square rounded-full text-[8px]'>
+          <p
+            className='absolute right-[-5px] bottom-[-5px] w-4 text-center leading-4 bg-black text-white aspect-square rounded-full text-[8px]'
+            data-testid='navbar-cart-count'
+          >
             {getCartCount()}
           </p>
         </Link>

--- a/frontend/src/components/ProductItem.jsx
+++ b/frontend/src/components/ProductItem.jsx
@@ -5,7 +5,12 @@ import { Link } from 'react-router-dom'
 const ProductItem = ({ id, image, name, price }) => {
   const { currency } = useContext(ShopContext)
   return (
-    <Link to={`/product/${id}`} className='text-gray-700 cursor-pointer'>
+    <Link
+      to={`/product/${id}`}
+      className='text-gray-700 cursor-pointer'
+      data-testid='product-card'
+      data-product-name={name}
+    >
       <div className='overflow-hidden'>
         <img
           src={image[0]}
@@ -13,8 +18,10 @@ const ProductItem = ({ id, image, name, price }) => {
           className='hover:scale-110 transition ease-in-out'
         />
       </div>
-      <p className='pt-3 pb-1 text-sm'>{name}</p>
-      <p className='text-sm font-medium'>
+      <p className='pt-3 pb-1 text-sm' data-testid='product-card-name'>
+        {name}
+      </p>
+      <p className='text-sm font-medium' data-testid='product-card-price'>
         {currency}
         {price}
       </p>

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -27,6 +27,7 @@ const SearchBar = () => {
           className='flex-1 outline-none bg-inherit text-sm'
           value={search}
           onChange={(e) => setSearch(e.target.value)}
+          data-testid='search-input'
         />
 
         <img src={assets.search_icon} className='w-4' alt='' />

--- a/frontend/src/pages/Cart.jsx
+++ b/frontend/src/pages/Cart.jsx
@@ -44,6 +44,8 @@ const Cart = () => {
             <div
               className='py-4 border-t border-b text-gray-700 grid grid-cols-[4fr_0.5fr_0.5fr] sm:grid-cols-[4fr_2fr_0.5fr] items-center gap-4'
               key={i}
+              data-testid='cart-item'
+              data-product-id={item._id}
             >
               <div className='flex items-start gap-6'>
                 <img
@@ -52,15 +54,21 @@ const Cart = () => {
                   alt=''
                 />
                 <div>
-                  <p className='text-xs sm:text-lg font-medium'>
+                  <p
+                    className='text-xs sm:text-lg font-medium'
+                    data-testid='cart-item-name'
+                  >
                     {productsData.name}
                   </p>
                   <div className='flex items-center gap-5 mt-2'>
-                    <p>
+                    <p data-testid='cart-item-price'>
                       {currency}
                       {productsData.price}
                     </p>
-                    <p className='px-2 sm:px-3 sm:py-1 border bg-stale-50'>
+                    <p
+                      className='px-2 sm:px-3 sm:py-1 border bg-stale-50'
+                      data-testid='cart-item-size'
+                    >
                       {item.size}
                     </p>
                   </div>
@@ -81,12 +89,14 @@ const Cart = () => {
                         Number(e.target.value)
                       )
                 }
+                data-testid='cart-item-quantity'
               />
               <img
                 src={assets.bin_icon}
                 className='w-4 mr-4 sm:w-5 cursor-pointer'
                 alt=''
                 onClick={() => updateQuantity(item._id, item.size, 0)}
+                data-testid='cart-item-remove'
               />
             </div>
           )
@@ -100,6 +110,7 @@ const Cart = () => {
             <button
               className='bg-black text-white text-sm my-8 px-8 py-3'
               onClick={() => navigate('/place-order')}
+              data-testid='proceed-to-checkout-button'
             >
               PROCEED TO CHECKOUT
             </button>

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -108,6 +108,7 @@ const Collection = () => {
                 type='checkbox'
                 value={'Men'}
                 onChange={toggleCategory}
+                data-testid='filter-category-men'
               />{' '}
               Men
             </p>
@@ -117,6 +118,7 @@ const Collection = () => {
                 type='checkbox'
                 value={'Women'}
                 onChange={toggleCategory}
+                data-testid='filter-category-women'
               />{' '}
               Women
             </p>
@@ -126,6 +128,7 @@ const Collection = () => {
                 type='checkbox'
                 value={'Kids'}
                 onChange={toggleCategory}
+                data-testid='filter-category-kids'
               />{' '}
               Kids
             </p>
@@ -146,6 +149,7 @@ const Collection = () => {
                 type='checkbox'
                 value={'Topwear'}
                 onChange={toggleSubCategory}
+                data-testid='filter-subcategory-topwear'
               />{' '}
               Topwear
             </p>
@@ -155,6 +159,7 @@ const Collection = () => {
                 type='checkbox'
                 value={'Bottomwear'}
                 onChange={toggleSubCategory}
+                data-testid='filter-subcategory-bottomwear'
               />{' '}
               Bottomwear
             </p>
@@ -164,6 +169,7 @@ const Collection = () => {
                 type='checkbox'
                 value={'Winterwear'}
                 onChange={toggleSubCategory}
+                data-testid='filter-subcategory-winterwear'
               />{' '}
               Winterwear
             </p>
@@ -180,6 +186,7 @@ const Collection = () => {
           <select
             onChange={(e) => setSortType(e.target.value)}
             className='border-2 border-gray-300 text-sm px-2'
+            data-testid='sort-select'
           >
             <option value='relevant'>Sort by: Relevant</option>
             <option value='low-high'>Sort by: Low to High</option>
@@ -188,7 +195,10 @@ const Collection = () => {
         </div>
 
         {/* MAP PRODUCTS */}
-        <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 gap-y-6'>
+        <div
+          className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 gap-y-6'
+          data-testid='product-grid'
+        >
           {filterProducts.map((item, i) => (
             <ProductItem
               key={i}

--- a/frontend/src/pages/Product.jsx
+++ b/frontend/src/pages/Product.jsx
@@ -77,6 +77,7 @@ const Product = () => {
                   }`}
                   key={i}
                   onClick={() => setSize(item)}
+                  data-testid={`product-size-${item}`}
                 >
                   {item}
                 </button>
@@ -87,6 +88,7 @@ const Product = () => {
           <button
             className='bg-black text-white px-8 py-3 text-sm active:bg-gray-700'
             onClick={() => addToCart(productData._id, size)}
+            data-testid='add-to-cart-button'
           >
             ADD TO CART
           </button>


### PR DESCRIPTION
## Summary
- Adds guest-user e2e coverage: category/type/combo product filtering (`product_filters.spec.cy.ts`) and the guest cart+checkout flow (`guest_checkout.spec.cy.ts`) — add-to-cart, quantity updates, price/total math, and checkout being rejected for guests.
- Adds `data-testid` attributes across `Collection.jsx`, `Product.jsx`, `Cart.jsx`, `CartTotal.jsx`, `ProductItem.jsx`, `SearchBar.jsx`, and `Navbar.jsx` (search icon, cart/collection links, cart row fields) to give the new specs stable selectors.

## Notable findings (not fixed here, flagged for follow-up)
- `PlaceOrder.jsx` has no client-side auth guard — guests can submit checkout; only the backend's `authUser` middleware rejects with a 401. Test asserts the current (backend-401) behavior.
- Guest `cartItems` in `ShopContext.jsx` lives only in React state, never persisted — a full page reload/`cy.visit` silently empties a guest's cart. Tests work around this by navigating via in-app links instead of `cy.visit`.

## Test plan
- [x] `product_filters.spec.cy.ts` passes locally against the docker-compose dev stack
- [x] `guest_checkout.spec.cy.ts` passes locally against the docker-compose dev stack
- [x] Verified `docker:seed` picks up the two new seed products in a fresh build
- [x] Confirm green in CI (`e2e-tests.yml`)